### PR TITLE
Use sigemptyset() to initialize sigset_t

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,7 +275,7 @@ static void write_loop(std::string name, int32_t width, int32_t height)
 {
     /* Ignore SIGINT, main loop is responsible for the exit_main_loop signal */
     sigset_t sigset;
-    sigisemptyset(&sigset);
+    sigemptyset(&sigset);
     sigaddset(&sigset, SIGINT);
     pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 


### PR DESCRIPTION
sigisemptyset() is a glibc only function per [1] that can be used
to check if a sigset_t is empty which is not needed here.  This
also fixes the build on FreeBSD where sigisemptyset() is not
available.

[1] https://linux.die.net/man/3/sigemptyset