### PR TITLE
src: untabify

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -13,11 +13,11 @@ class FFmpegInitialize
 {
 public :
 
-	FFmpegInitialize()
-	{
-		// Loads the whole database of available codecs and formats.
-		av_register_all();
-	}
+        FFmpegInitialize()
+        {
+                // Loads the whole database of available codecs and formats.
+                av_register_all();
+        }
 };
 
 static FFmpegInitialize ffmpegInitialize;
@@ -39,55 +39,55 @@ FrameWriter::FrameWriter(const string& filename, int width_, int height_, InputF
             break;
     }
 
-	// Preparing the data concerning the format and codec,
-	// in order to write properly the header, frame data and end of file.
-	fmt = av_guess_format(NULL, filename.c_str(), NULL);
-	avformat_alloc_output_context2(&fc, NULL, NULL, filename.c_str());
+        // Preparing the data concerning the format and codec,
+        // in order to write properly the header, frame data and end of file.
+        fmt = av_guess_format(NULL, filename.c_str(), NULL);
+        avformat_alloc_output_context2(&fc, NULL, NULL, filename.c_str());
 
-	// Setting up the codec.
-	AVCodec* codec = avcodec_find_encoder_by_name("libx264");
-	AVDictionary* opt = NULL;
+        // Setting up the codec.
+        AVCodec* codec = avcodec_find_encoder_by_name("libx264");
+        AVDictionary* opt = NULL;
     av_dict_set(&opt, "tune", "zerolatency", 0);
-	av_dict_set(&opt, "preset", "ultrafast", 0);
-	av_dict_set(&opt, "crf", "20", 0);
+        av_dict_set(&opt, "preset", "ultrafast", 0);
+        av_dict_set(&opt, "crf", "20", 0);
 
-	stream = avformat_new_stream(fc, codec);
-	c = stream->codec;
-	c->width = width;
-	c->height = height;
-	c->pix_fmt = AV_PIX_FMT_YUV420P;
-	c->time_base = (AVRational){ 1, FPS };
+        stream = avformat_new_stream(fc, codec);
+        c = stream->codec;
+        c->width = width;
+        c->height = height;
+        c->pix_fmt = AV_PIX_FMT_YUV420P;
+        c->time_base = (AVRational){ 1, FPS };
 
-	// Setting up the format, its stream(s),
-	// linking with the codec(s) and write the header.
-	if (fc->oformat->flags & AVFMT_GLOBALHEADER)
-	{
-		// Some formats require a global header.
-		c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
-	}
-	avcodec_open2(c, codec, &opt);
-	av_dict_free(&opt);
+        // Setting up the format, its stream(s),
+        // linking with the codec(s) and write the header.
+        if (fc->oformat->flags & AVFMT_GLOBALHEADER)
+        {
+                // Some formats require a global header.
+                c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        }
+        avcodec_open2(c, codec, &opt);
+        av_dict_free(&opt);
 
-	// Once the codec is set up, we need to let the container know
-	// which codec are the streams using, in this case the only (video) stream.
-	stream->time_base = (AVRational){ 1, FPS };
-	av_dump_format(fc, 0, filename.c_str(), 1);
-	avio_open(&fc->pb, filename.c_str(), AVIO_FLAG_WRITE);
-	int ret = avformat_write_header(fc, &opt);
-	av_dict_free(&opt);
+        // Once the codec is set up, we need to let the container know
+        // which codec are the streams using, in this case the only (video) stream.
+        stream->time_base = (AVRational){ 1, FPS };
+        av_dump_format(fc, 0, filename.c_str(), 1);
+        avio_open(&fc->pb, filename.c_str(), AVIO_FLAG_WRITE);
+        int ret = avformat_write_header(fc, &opt);
+        av_dict_free(&opt);
 
-	// Allocating memory for each conversion output YUV frame.
-	yuvpic = av_frame_alloc();
-	yuvpic->format = AV_PIX_FMT_YUV420P;
-	yuvpic->width = width;
-	yuvpic->height = height;
-	ret = av_frame_get_buffer(yuvpic, 1);
+        // Allocating memory for each conversion output YUV frame.
+        yuvpic = av_frame_alloc();
+        yuvpic->format = AV_PIX_FMT_YUV420P;
+        yuvpic->width = width;
+        yuvpic->height = height;
+        ret = av_frame_get_buffer(yuvpic, 1);
 }
 
 void FrameWriter::add_frame(const uint8_t* pixels, int msec, bool y_invert)
 {
-	// Not actually scaling anything, but just converting
-	// the RGB data to YUV and store it in yuvpic.
+        // Not actually scaling anything, but just converting
+        // the RGB data to YUV and store it in yuvpic.
     int stride[] = {int(4 * width)};
     const uint8_t *formatted_pixels = pixels;
 
@@ -98,55 +98,54 @@ void FrameWriter::add_frame(const uint8_t* pixels, int msec, bool y_invert)
     }
 
     sws_scale(swsCtx, &formatted_pixels, stride, 0,
-    	height, yuvpic->data, yuvpic->linesize);
+        height, yuvpic->data, yuvpic->linesize);
 
-	av_init_packet(&pkt);
-	pkt.data = NULL;
-	pkt.size = 0;
+        av_init_packet(&pkt);
+        pkt.data = NULL;
+        pkt.size = 0;
 
-	yuvpic->pts = msec;
+        yuvpic->pts = msec;
 
-	int got_output;
-	avcodec_encode_video2(c, &pkt, yuvpic, &got_output);
-	if (got_output)
-		finish_frame();
+        int got_output;
+        avcodec_encode_video2(c, &pkt, yuvpic, &got_output);
+        if (got_output)
+                finish_frame();
 }
 
 void FrameWriter::finish_frame()
 {
-	static int iframe = 0;
-	av_packet_rescale_ts(&pkt, (AVRational){ 1, 1000 }, stream->time_base);
+        static int iframe = 0;
+        av_packet_rescale_ts(&pkt, (AVRational){ 1, 1000 }, stream->time_base);
 
-	pkt.stream_index = stream->index;
+        pkt.stream_index = stream->index;
 
-	av_interleaved_write_frame(fc, &pkt);
-	av_packet_unref(&pkt);
+        av_interleaved_write_frame(fc, &pkt);
+        av_packet_unref(&pkt);
 
-	printf("Wrote frame %d\n", iframe++);
-	fflush(stdout);
+        printf("Wrote frame %d\n", iframe++);
+        fflush(stdout);
 }
 
 FrameWriter::~FrameWriter()
 {
-	// Writing the delayed frames:
-	for (int got_output = 1; got_output; )
-	{
-		avcodec_encode_video2(c, &pkt, NULL, &got_output);
-		if (got_output)
-			finish_frame();
-	}
+        // Writing the delayed frames:
+        for (int got_output = 1; got_output; )
+        {
+                avcodec_encode_video2(c, &pkt, NULL, &got_output);
+                if (got_output)
+                        finish_frame();
+        }
 
-	// Writing the end of the file.
-	av_write_trailer(fc);
+        // Writing the end of the file.
+        av_write_trailer(fc);
 
-	// Closing the file.
-	if (!(fmt->flags & AVFMT_NOFILE))
-	    avio_closep(&fc->pb);
-	avcodec_close(stream->codec);
+        // Closing the file.
+        if (!(fmt->flags & AVFMT_NOFILE))
+            avio_closep(&fc->pb);
+        avcodec_close(stream->codec);
 
-	// Freeing all the allocated memory:
-	sws_freeContext(swsCtx);
-	av_frame_free(&yuvpic);
-	avformat_free_context(fc);
+        // Freeing all the allocated memory:
+        sws_freeContext(swsCtx);
+        av_frame_free(&yuvpic);
+        avformat_free_context(fc);
 }
-

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -13,11 +13,11 @@ class FFmpegInitialize
 {
 public :
 
-        FFmpegInitialize()
-        {
-                // Loads the whole database of available codecs and formats.
-                av_register_all();
-        }
+    FFmpegInitialize()
+    {
+        // Loads the whole database of available codecs and formats.
+        av_register_all();
+    }
 };
 
 static FFmpegInitialize ffmpegInitialize;
@@ -39,55 +39,55 @@ FrameWriter::FrameWriter(const string& filename, int width_, int height_, InputF
             break;
     }
 
-        // Preparing the data concerning the format and codec,
-        // in order to write properly the header, frame data and end of file.
-        fmt = av_guess_format(NULL, filename.c_str(), NULL);
-        avformat_alloc_output_context2(&fc, NULL, NULL, filename.c_str());
+    // Preparing the data concerning the format and codec,
+    // in order to write properly the header, frame data and end of file.
+    fmt = av_guess_format(NULL, filename.c_str(), NULL);
+    avformat_alloc_output_context2(&fc, NULL, NULL, filename.c_str());
 
-        // Setting up the codec.
-        AVCodec* codec = avcodec_find_encoder_by_name("libx264");
-        AVDictionary* opt = NULL;
+    // Setting up the codec.
+    AVCodec* codec = avcodec_find_encoder_by_name("libx264");
+    AVDictionary* opt = NULL;
     av_dict_set(&opt, "tune", "zerolatency", 0);
-        av_dict_set(&opt, "preset", "ultrafast", 0);
-        av_dict_set(&opt, "crf", "20", 0);
+    av_dict_set(&opt, "preset", "ultrafast", 0);
+    av_dict_set(&opt, "crf", "20", 0);
 
-        stream = avformat_new_stream(fc, codec);
-        c = stream->codec;
-        c->width = width;
-        c->height = height;
-        c->pix_fmt = AV_PIX_FMT_YUV420P;
-        c->time_base = (AVRational){ 1, FPS };
+    stream = avformat_new_stream(fc, codec);
+    c = stream->codec;
+    c->width = width;
+    c->height = height;
+    c->pix_fmt = AV_PIX_FMT_YUV420P;
+    c->time_base = (AVRational){ 1, FPS };
 
-        // Setting up the format, its stream(s),
-        // linking with the codec(s) and write the header.
-        if (fc->oformat->flags & AVFMT_GLOBALHEADER)
-        {
-                // Some formats require a global header.
-                c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
-        }
-        avcodec_open2(c, codec, &opt);
-        av_dict_free(&opt);
+    // Setting up the format, its stream(s),
+    // linking with the codec(s) and write the header.
+    if (fc->oformat->flags & AVFMT_GLOBALHEADER)
+    {
+        // Some formats require a global header.
+        c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    }
+    avcodec_open2(c, codec, &opt);
+    av_dict_free(&opt);
 
-        // Once the codec is set up, we need to let the container know
-        // which codec are the streams using, in this case the only (video) stream.
-        stream->time_base = (AVRational){ 1, FPS };
-        av_dump_format(fc, 0, filename.c_str(), 1);
-        avio_open(&fc->pb, filename.c_str(), AVIO_FLAG_WRITE);
-        int ret = avformat_write_header(fc, &opt);
-        av_dict_free(&opt);
+    // Once the codec is set up, we need to let the container know
+    // which codec are the streams using, in this case the only (video) stream.
+    stream->time_base = (AVRational){ 1, FPS };
+    av_dump_format(fc, 0, filename.c_str(), 1);
+    avio_open(&fc->pb, filename.c_str(), AVIO_FLAG_WRITE);
+    int ret = avformat_write_header(fc, &opt);
+    av_dict_free(&opt);
 
-        // Allocating memory for each conversion output YUV frame.
-        yuvpic = av_frame_alloc();
-        yuvpic->format = AV_PIX_FMT_YUV420P;
-        yuvpic->width = width;
-        yuvpic->height = height;
-        ret = av_frame_get_buffer(yuvpic, 1);
+    // Allocating memory for each conversion output YUV frame.
+    yuvpic = av_frame_alloc();
+    yuvpic->format = AV_PIX_FMT_YUV420P;
+    yuvpic->width = width;
+    yuvpic->height = height;
+    ret = av_frame_get_buffer(yuvpic, 1);
 }
 
 void FrameWriter::add_frame(const uint8_t* pixels, int msec, bool y_invert)
 {
-        // Not actually scaling anything, but just converting
-        // the RGB data to YUV and store it in yuvpic.
+    // Not actually scaling anything, but just converting
+    // the RGB data to YUV and store it in yuvpic.
     int stride[] = {int(4 * width)};
     const uint8_t *formatted_pixels = pixels;
 
@@ -100,52 +100,52 @@ void FrameWriter::add_frame(const uint8_t* pixels, int msec, bool y_invert)
     sws_scale(swsCtx, &formatted_pixels, stride, 0,
         height, yuvpic->data, yuvpic->linesize);
 
-        av_init_packet(&pkt);
-        pkt.data = NULL;
-        pkt.size = 0;
+    av_init_packet(&pkt);
+    pkt.data = NULL;
+    pkt.size = 0;
 
-        yuvpic->pts = msec;
+    yuvpic->pts = msec;
 
-        int got_output;
-        avcodec_encode_video2(c, &pkt, yuvpic, &got_output);
-        if (got_output)
-                finish_frame();
+    int got_output;
+    avcodec_encode_video2(c, &pkt, yuvpic, &got_output);
+    if (got_output)
+      finish_frame();
 }
 
 void FrameWriter::finish_frame()
 {
-        static int iframe = 0;
-        av_packet_rescale_ts(&pkt, (AVRational){ 1, 1000 }, stream->time_base);
+    static int iframe = 0;
+    av_packet_rescale_ts(&pkt, (AVRational){ 1, 1000 }, stream->time_base);
 
-        pkt.stream_index = stream->index;
+    pkt.stream_index = stream->index;
 
-        av_interleaved_write_frame(fc, &pkt);
-        av_packet_unref(&pkt);
+    av_interleaved_write_frame(fc, &pkt);
+    av_packet_unref(&pkt);
 
-        printf("Wrote frame %d\n", iframe++);
-        fflush(stdout);
+    printf("Wrote frame %d\n", iframe++);
+    fflush(stdout);
 }
 
 FrameWriter::~FrameWriter()
 {
-        // Writing the delayed frames:
-        for (int got_output = 1; got_output; )
-        {
-                avcodec_encode_video2(c, &pkt, NULL, &got_output);
-                if (got_output)
-                        finish_frame();
-        }
+    // Writing the delayed frames:
+    for (int got_output = 1; got_output; )
+    {
+        avcodec_encode_video2(c, &pkt, NULL, &got_output);
+        if (got_output)
+            finish_frame();
+    }
 
-        // Writing the end of the file.
-        av_write_trailer(fc);
+    // Writing the end of the file.
+    av_write_trailer(fc);
 
-        // Closing the file.
-        if (!(fmt->flags & AVFMT_NOFILE))
-            avio_closep(&fc->pb);
-        avcodec_close(stream->codec);
+    // Closing the file.
+    if (!(fmt->flags & AVFMT_NOFILE))
+        avio_closep(&fc->pb);
+    avcodec_close(stream->codec);
 
-        // Freeing all the allocated memory:
-        sws_freeContext(swsCtx);
-        av_frame_free(&yuvpic);
-        avformat_free_context(fc);
+    // Freeing all the allocated memory:
+    sws_freeContext(swsCtx);
+    av_frame_free(&yuvpic);
+    avformat_free_context(fc);
 }

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -11,12 +11,12 @@
 
 extern "C"
 {
-	#include <x264.h>
-	#include <libswscale/swscale.h>
-	#include <libavcodec/avcodec.h>
-	#include <libavutil/mathematics.h>
-	#include <libavformat/avformat.h>
-	#include <libavutil/opt.h>
+        #include <x264.h>
+        #include <libswscale/swscale.h>
+        #include <libavcodec/avcodec.h>
+        #include <libavutil/mathematics.h>
+        #include <libavformat/avformat.h>
+        #include <libavutil/opt.h>
 }
 
 enum InputFormat
@@ -27,24 +27,23 @@ enum InputFormat
 
 class FrameWriter
 {
-	const unsigned int width, height;
+        const unsigned int width, height;
 
-	SwsContext* swsCtx;
-	AVOutputFormat* fmt;
-	AVStream* stream;
-	AVFormatContext* fc;
-	AVCodecContext* c;
-	AVPacket pkt;
+        SwsContext* swsCtx;
+        AVOutputFormat* fmt;
+        AVStream* stream;
+        AVFormatContext* fc;
+        AVCodecContext* c;
+        AVPacket pkt;
 
-	AVFrame *yuvpic;
-	void finish_frame();
+        AVFrame *yuvpic;
+        void finish_frame();
 
 public :
-	FrameWriter(const std::string& filename,
+        FrameWriter(const std::string& filename,
         int width, int height, InputFormat format);
-	void add_frame(const uint8_t* pixels, int msec, bool y_invert);
-	~FrameWriter();
+        void add_frame(const uint8_t* pixels, int msec, bool y_invert);
+        ~FrameWriter();
 };
 
 #endif // FRAME_WRITER
-

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -11,39 +11,39 @@
 
 extern "C"
 {
-        #include <x264.h>
-        #include <libswscale/swscale.h>
-        #include <libavcodec/avcodec.h>
-        #include <libavutil/mathematics.h>
-        #include <libavformat/avformat.h>
-        #include <libavutil/opt.h>
+    #include <x264.h>
+    #include <libswscale/swscale.h>
+    #include <libavcodec/avcodec.h>
+    #include <libavutil/mathematics.h>
+    #include <libavformat/avformat.h>
+    #include <libavutil/opt.h>
 }
 
 enum InputFormat
 {
-    INPUT_FORMAT_BGR0,
-    INPUT_FORMAT_RGB0
+     INPUT_FORMAT_BGR0,
+     INPUT_FORMAT_RGB0
 };
 
 class FrameWriter
 {
-        const unsigned int width, height;
+    const unsigned int width, height;
 
-        SwsContext* swsCtx;
-        AVOutputFormat* fmt;
-        AVStream* stream;
-        AVFormatContext* fc;
-        AVCodecContext* c;
-        AVPacket pkt;
+    SwsContext* swsCtx;
+    AVOutputFormat* fmt;
+    AVStream* stream;
+    AVFormatContext* fc;
+    AVCodecContext* c;
+    AVPacket pkt;
 
-        AVFrame *yuvpic;
-        void finish_frame();
+    AVFrame *yuvpic;
+    void finish_frame();
 
 public :
-        FrameWriter(const std::string& filename,
+    FrameWriter(const std::string& filename,
         int width, int height, InputFormat format);
-        void add_frame(const uint8_t* pixels, int msec, bool y_invert);
-        ~FrameWriter();
+    void add_frame(const uint8_t* pixels, int msec, bool y_invert);
+    ~FrameWriter();
 };
 
 #endif // FRAME_WRITER

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,11 +93,11 @@ const zxdg_output_v1_listener xdg_output_implementation = {
 
 struct wf_buffer
 {
-	struct wl_buffer *wl_buffer;
-	void *data;
-	enum wl_shm_format format;
-	int width, height, stride;
-	bool y_invert;
+        struct wl_buffer *wl_buffer;
+        void *data;
+        enum wl_shm_format format;
+        int width, height, stride;
+        bool y_invert;
 
     timespec presented;
     uint32_t base_msec;
@@ -116,61 +116,61 @@ bool buffer_copy_done = false;
 
 static int backingfile(off_t size)
 {
-	char name[] = "/tmp/wf-recorder-shared-XXXXXX";
-	int fd = mkstemp(name);
-	if (fd < 0) {
-		return -1;
-	}
+        char name[] = "/tmp/wf-recorder-shared-XXXXXX";
+        int fd = mkstemp(name);
+        if (fd < 0) {
+                return -1;
+        }
 
-	int ret;
-	while ((ret = ftruncate(fd, size)) == EINTR) {
-		// No-op
-	}
-	if (ret < 0) {
-		close(fd);
-		return -1;
-	}
+        int ret;
+        while ((ret = ftruncate(fd, size)) == EINTR) {
+                // No-op
+        }
+        if (ret < 0) {
+                close(fd);
+                return -1;
+        }
 
-	unlink(name);
-	return fd;
+        unlink(name);
+        return fd;
 }
 
 static struct wl_buffer *create_shm_buffer(uint32_t fmt,
-		int width, int height, int stride, void **data_out)
+                int width, int height, int stride, void **data_out)
 {
-	int size = stride * height;
+        int size = stride * height;
 
-	int fd = backingfile(size);
-	if (fd < 0) {
-		fprintf(stderr, "creating a buffer file for %d B failed: %m\n", size);
-		return NULL;
-	}
+        int fd = backingfile(size);
+        if (fd < 0) {
+                fprintf(stderr, "creating a buffer file for %d B failed: %m\n", size);
+                return NULL;
+        }
 
-	void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if (data == MAP_FAILED) {
-		fprintf(stderr, "mmap failed: %m\n");
-		close(fd);
-		return NULL;
-	}
+        void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        if (data == MAP_FAILED) {
+                fprintf(stderr, "mmap failed: %m\n");
+                close(fd);
+                return NULL;
+        }
 
-	struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
-	close(fd);
-	struct wl_buffer *buffer = wl_shm_pool_create_buffer(pool, 0, width, height,
-		stride, fmt);
-	wl_shm_pool_destroy(pool);
+        struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
+        close(fd);
+        struct wl_buffer *buffer = wl_shm_pool_create_buffer(pool, 0, width, height,
+                stride, fmt);
+        wl_shm_pool_destroy(pool);
 
-	*data_out = data;
-	return buffer;
+        *data_out = data;
+        return buffer;
 }
 
 static void frame_handle_buffer(void *, struct zwlr_screencopy_frame_v1 *frame, uint32_t format,
-		uint32_t width, uint32_t height, uint32_t stride)
+                uint32_t width, uint32_t height, uint32_t stride)
 {
     auto& buffer = buffers[active_buffer];
 
-	buffer.format = (wl_shm_format)format;
-	buffer.width = width;
-	buffer.height = height;
+        buffer.format = (wl_shm_format)format;
+        buffer.width = width;
+        buffer.height = height;
     buffer.stride = stride;
 
     if (!buffer.wl_buffer) {
@@ -178,57 +178,57 @@ static void frame_handle_buffer(void *, struct zwlr_screencopy_frame_v1 *frame, 
             create_shm_buffer(format, width, height, stride, &buffer.data);
     }
 
-	if (buffer.wl_buffer == NULL) {
-		fprintf(stderr, "failed to create buffer\n");
-		exit(EXIT_FAILURE);
-	}
+        if (buffer.wl_buffer == NULL) {
+                fprintf(stderr, "failed to create buffer\n");
+                exit(EXIT_FAILURE);
+        }
 
-	zwlr_screencopy_frame_v1_copy(frame, buffer.wl_buffer);
+        zwlr_screencopy_frame_v1_copy(frame, buffer.wl_buffer);
 }
 
 static void frame_handle_flags(void*, struct zwlr_screencopy_frame_v1 *, uint32_t flags) {
-	buffers[active_buffer].y_invert = flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT;
+        buffers[active_buffer].y_invert = flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT;
 }
 
 static void frame_handle_ready(void *, struct zwlr_screencopy_frame_v1 *,
     uint32_t tv_sec_hi, uint32_t tv_sec_low, uint32_t tv_nsec) {
 
     auto& buffer = buffers[active_buffer];
-	buffer_copy_done = true;
+        buffer_copy_done = true;
     buffer.presented.tv_sec = ((1ll * tv_sec_hi) << 32ll) | tv_sec_low;
     buffer.presented.tv_nsec = tv_nsec;
 }
 
 static void frame_handle_failed(void *, struct zwlr_screencopy_frame_v1 *) {
-	fprintf(stderr, "failed to copy frame\n");
+        fprintf(stderr, "failed to copy frame\n");
     exit_main_loop = true;
 }
 
 static const struct zwlr_screencopy_frame_v1_listener frame_listener = {
-	.buffer = frame_handle_buffer,
-	.flags = frame_handle_flags,
-	.ready = frame_handle_ready,
-	.failed = frame_handle_failed,
+        .buffer = frame_handle_buffer,
+        .flags = frame_handle_flags,
+        .ready = frame_handle_ready,
+        .failed = frame_handle_failed,
 };
 
 static void handle_global(void*, struct wl_registry *registry,
-		uint32_t name, const char *interface, uint32_t) {
-	if (strcmp(interface, wl_output_interface.name) == 0)
+                uint32_t name, const char *interface, uint32_t) {
+        if (strcmp(interface, wl_output_interface.name) == 0)
     {
-		auto output = (wl_output*)wl_registry_bind(registry, name, &wl_output_interface, 1);
+                auto output = (wl_output*)wl_registry_bind(registry, name, &wl_output_interface, 1);
         wf_recorder_output wro;
         wro.output = output;
         available_outputs.push_back(wro);
-	}
+        }
     else if (strcmp(interface, wl_shm_interface.name) == 0)
     {
-		shm = (wl_shm*) wl_registry_bind(registry, name, &wl_shm_interface, 1);
-	}
+                shm = (wl_shm*) wl_registry_bind(registry, name, &wl_shm_interface, 1);
+        }
     else if (strcmp(interface, zwlr_screencopy_manager_v1_interface.name) == 0)
     {
-		screencopy_manager = (zwlr_screencopy_manager_v1*) wl_registry_bind(registry, name,
-			&zwlr_screencopy_manager_v1_interface, 1);
-	}
+                screencopy_manager = (zwlr_screencopy_manager_v1*) wl_registry_bind(registry, name,
+                        &zwlr_screencopy_manager_v1_interface, 1);
+        }
     else if (strcmp(interface, zxdg_output_manager_v1_interface.name) == 0)
     {
         xdg_output_manager = (zxdg_output_manager_v1*) wl_registry_bind(registry, name,
@@ -237,12 +237,12 @@ static void handle_global(void*, struct wl_registry *registry,
 }
 
 static void handle_global_remove(void*, struct wl_registry *, uint32_t) {
-	// Who cares?
+        // Who cares?
 }
 
 static const struct wl_registry_listener registry_listener = {
-	.global = handle_global,
-	.global_remove = handle_global_remove,
+        .global = handle_global,
+        .global_remove = handle_global_remove,
 };
 
 static uint64_t timespec_to_msec (const timespec& ts)
@@ -316,14 +316,14 @@ void handle_sigint(int)
 
 static void check_has_protos()
 {
-	if (shm == NULL) {
-		fprintf(stderr, "compositor is missing wl_shm\n");
+        if (shm == NULL) {
+                fprintf(stderr, "compositor is missing wl_shm\n");
         exit(EXIT_FAILURE);
-	}
-	if (screencopy_manager == NULL) {
-		fprintf(stderr, "compositor doesn't support wlr-screencopy-unstable-v1\n");
-		exit(EXIT_FAILURE);
-	}
+        }
+        if (screencopy_manager == NULL) {
+                fprintf(stderr, "compositor doesn't support wlr-screencopy-unstable-v1\n");
+                exit(EXIT_FAILURE);
+        }
 
     if (xdg_output_manager == NULL)
     {
@@ -331,18 +331,18 @@ static void check_has_protos()
         exit(EXIT_FAILURE);
     }
 
-	if (available_outputs.empty())
+        if (available_outputs.empty())
     {
-		fprintf(stderr, "no outputs available\n");
-		exit(EXIT_FAILURE);
-	}
+                fprintf(stderr, "no outputs available\n");
+                exit(EXIT_FAILURE);
+        }
 }
 
 wl_display *display = NULL;
 static void sync_wayland()
 {
-	wl_display_dispatch(display);
-	wl_display_roundtrip(display);
+        wl_display_dispatch(display);
+        wl_display_roundtrip(display);
 }
 
 
@@ -473,14 +473,14 @@ int main(int argc, char *argv[])
         }
     }
 
-	display = wl_display_connect(NULL);
-	if (display == NULL) {
-		fprintf(stderr, "failed to create display: %m\n");
-		return EXIT_FAILURE;
-	}
+        display = wl_display_connect(NULL);
+        if (display == NULL) {
+                fprintf(stderr, "failed to create display: %m\n");
+                return EXIT_FAILURE;
+        }
 
-	struct wl_registry *registry = wl_display_get_registry(display);
-	wl_registry_add_listener(registry, &registry_listener, NULL);
+        struct wl_registry *registry = wl_display_get_registry(display);
+        wl_registry_add_listener(registry, &registry_listener, NULL);
     sync_wayland();
 
     check_has_protos();
@@ -605,5 +605,5 @@ int main(int argc, char *argv[])
     for (auto& buffer : buffers)
         wl_buffer_destroy(buffer.wl_buffer);
 
-	return EXIT_SUCCESS;
+        return EXIT_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,11 +93,11 @@ const zxdg_output_v1_listener xdg_output_implementation = {
 
 struct wf_buffer
 {
-        struct wl_buffer *wl_buffer;
-        void *data;
-        enum wl_shm_format format;
-        int width, height, stride;
-        bool y_invert;
+    struct wl_buffer *wl_buffer;
+    void *data;
+    enum wl_shm_format format;
+    int width, height, stride;
+    bool y_invert;
 
     timespec presented;
     uint32_t base_msec;
@@ -116,61 +116,61 @@ bool buffer_copy_done = false;
 
 static int backingfile(off_t size)
 {
-        char name[] = "/tmp/wf-recorder-shared-XXXXXX";
-        int fd = mkstemp(name);
-        if (fd < 0) {
-                return -1;
-        }
+    char name[] = "/tmp/wf-recorder-shared-XXXXXX";
+    int fd = mkstemp(name);
+    if (fd < 0) {
+        return -1;
+    }
 
-        int ret;
-        while ((ret = ftruncate(fd, size)) == EINTR) {
-                // No-op
-        }
-        if (ret < 0) {
-                close(fd);
-                return -1;
-        }
+    int ret;
+    while ((ret = ftruncate(fd, size)) == EINTR) {
+        // No-op
+    }
+    if (ret < 0) {
+        close(fd);
+        return -1;
+    }
 
-        unlink(name);
-        return fd;
+    unlink(name);
+    return fd;
 }
 
 static struct wl_buffer *create_shm_buffer(uint32_t fmt,
-                int width, int height, int stride, void **data_out)
+    int width, int height, int stride, void **data_out)
 {
-        int size = stride * height;
+    int size = stride * height;
 
-        int fd = backingfile(size);
-        if (fd < 0) {
-                fprintf(stderr, "creating a buffer file for %d B failed: %m\n", size);
-                return NULL;
-        }
+    int fd = backingfile(size);
+    if (fd < 0) {
+        fprintf(stderr, "creating a buffer file for %d B failed: %m\n", size);
+        return NULL;
+    }
 
-        void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-        if (data == MAP_FAILED) {
-                fprintf(stderr, "mmap failed: %m\n");
-                close(fd);
-                return NULL;
-        }
-
-        struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
+    void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED) {
+        fprintf(stderr, "mmap failed: %m\n");
         close(fd);
-        struct wl_buffer *buffer = wl_shm_pool_create_buffer(pool, 0, width, height,
-                stride, fmt);
-        wl_shm_pool_destroy(pool);
+        return NULL;
+    }
 
-        *data_out = data;
-        return buffer;
+    struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
+    close(fd);
+    struct wl_buffer *buffer = wl_shm_pool_create_buffer(pool, 0, width, height,
+        stride, fmt);
+    wl_shm_pool_destroy(pool);
+
+    *data_out = data;
+    return buffer;
 }
 
 static void frame_handle_buffer(void *, struct zwlr_screencopy_frame_v1 *frame, uint32_t format,
-                uint32_t width, uint32_t height, uint32_t stride)
+    uint32_t width, uint32_t height, uint32_t stride)
 {
     auto& buffer = buffers[active_buffer];
 
-        buffer.format = (wl_shm_format)format;
-        buffer.width = width;
-        buffer.height = height;
+    buffer.format = (wl_shm_format)format;
+    buffer.width = width;
+    buffer.height = height;
     buffer.stride = stride;
 
     if (!buffer.wl_buffer) {
@@ -178,57 +178,58 @@ static void frame_handle_buffer(void *, struct zwlr_screencopy_frame_v1 *frame, 
             create_shm_buffer(format, width, height, stride, &buffer.data);
     }
 
-        if (buffer.wl_buffer == NULL) {
-                fprintf(stderr, "failed to create buffer\n");
-                exit(EXIT_FAILURE);
-        }
+    if (buffer.wl_buffer == NULL) {
+        fprintf(stderr, "failed to create buffer\n");
+        exit(EXIT_FAILURE);
+    }
 
-        zwlr_screencopy_frame_v1_copy(frame, buffer.wl_buffer);
+    zwlr_screencopy_frame_v1_copy(frame, buffer.wl_buffer);
 }
 
 static void frame_handle_flags(void*, struct zwlr_screencopy_frame_v1 *, uint32_t flags) {
-        buffers[active_buffer].y_invert = flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT;
+    buffers[active_buffer].y_invert = flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT;
 }
 
 static void frame_handle_ready(void *, struct zwlr_screencopy_frame_v1 *,
     uint32_t tv_sec_hi, uint32_t tv_sec_low, uint32_t tv_nsec) {
 
     auto& buffer = buffers[active_buffer];
-        buffer_copy_done = true;
+    buffer_copy_done = true;
     buffer.presented.tv_sec = ((1ll * tv_sec_hi) << 32ll) | tv_sec_low;
     buffer.presented.tv_nsec = tv_nsec;
 }
 
 static void frame_handle_failed(void *, struct zwlr_screencopy_frame_v1 *) {
-        fprintf(stderr, "failed to copy frame\n");
+    fprintf(stderr, "failed to copy frame\n");
     exit_main_loop = true;
 }
 
 static const struct zwlr_screencopy_frame_v1_listener frame_listener = {
-        .buffer = frame_handle_buffer,
-        .flags = frame_handle_flags,
-        .ready = frame_handle_ready,
-        .failed = frame_handle_failed,
+    .buffer = frame_handle_buffer,
+    .flags = frame_handle_flags,
+    .ready = frame_handle_ready,
+    .failed = frame_handle_failed,
 };
 
 static void handle_global(void*, struct wl_registry *registry,
-                uint32_t name, const char *interface, uint32_t) {
-        if (strcmp(interface, wl_output_interface.name) == 0)
+    uint32_t name, const char *interface, uint32_t) {
+
+    if (strcmp(interface, wl_output_interface.name) == 0)
     {
-                auto output = (wl_output*)wl_registry_bind(registry, name, &wl_output_interface, 1);
+        auto output = (wl_output*)wl_registry_bind(registry, name, &wl_output_interface, 1);
         wf_recorder_output wro;
         wro.output = output;
         available_outputs.push_back(wro);
-        }
+    }
     else if (strcmp(interface, wl_shm_interface.name) == 0)
     {
-                shm = (wl_shm*) wl_registry_bind(registry, name, &wl_shm_interface, 1);
-        }
+        shm = (wl_shm*) wl_registry_bind(registry, name, &wl_shm_interface, 1);
+    }
     else if (strcmp(interface, zwlr_screencopy_manager_v1_interface.name) == 0)
     {
-                screencopy_manager = (zwlr_screencopy_manager_v1*) wl_registry_bind(registry, name,
-                        &zwlr_screencopy_manager_v1_interface, 1);
-        }
+        screencopy_manager = (zwlr_screencopy_manager_v1*) wl_registry_bind(registry, name,
+            &zwlr_screencopy_manager_v1_interface, 1);
+    }
     else if (strcmp(interface, zxdg_output_manager_v1_interface.name) == 0)
     {
         xdg_output_manager = (zxdg_output_manager_v1*) wl_registry_bind(registry, name,
@@ -237,12 +238,12 @@ static void handle_global(void*, struct wl_registry *registry,
 }
 
 static void handle_global_remove(void*, struct wl_registry *, uint32_t) {
-        // Who cares?
+    // Who cares?
 }
 
 static const struct wl_registry_listener registry_listener = {
-        .global = handle_global,
-        .global_remove = handle_global_remove,
+    .global = handle_global,
+    .global_remove = handle_global_remove,
 };
 
 static uint64_t timespec_to_msec (const timespec& ts)
@@ -280,7 +281,7 @@ static void write_loop(std::string name, int32_t width, int32_t height)
     pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 
     std::unique_ptr<FrameWriter> writer;
-   // FrameWriter writer(name, width, height);
+    // FrameWriter writer(name, width, height);
 
     int last_encoded_frame = 0;
 
@@ -316,14 +317,14 @@ void handle_sigint(int)
 
 static void check_has_protos()
 {
-        if (shm == NULL) {
-                fprintf(stderr, "compositor is missing wl_shm\n");
+    if (shm == NULL) {
+        fprintf(stderr, "compositor is missing wl_shm\n");
         exit(EXIT_FAILURE);
-        }
-        if (screencopy_manager == NULL) {
-                fprintf(stderr, "compositor doesn't support wlr-screencopy-unstable-v1\n");
-                exit(EXIT_FAILURE);
-        }
+    }
+    if (screencopy_manager == NULL) {
+        fprintf(stderr, "compositor doesn't support wlr-screencopy-unstable-v1\n");
+        exit(EXIT_FAILURE);
+    }
 
     if (xdg_output_manager == NULL)
     {
@@ -331,18 +332,18 @@ static void check_has_protos()
         exit(EXIT_FAILURE);
     }
 
-        if (available_outputs.empty())
+    if (available_outputs.empty())
     {
-                fprintf(stderr, "no outputs available\n");
-                exit(EXIT_FAILURE);
-        }
+        fprintf(stderr, "no outputs available\n");
+        exit(EXIT_FAILURE);
+    }
 }
 
 wl_display *display = NULL;
 static void sync_wayland()
 {
-        wl_display_dispatch(display);
-        wl_display_roundtrip(display);
+    wl_display_dispatch(display);
+    wl_display_roundtrip(display);
 }
 
 
@@ -473,14 +474,14 @@ int main(int argc, char *argv[])
         }
     }
 
-        display = wl_display_connect(NULL);
-        if (display == NULL) {
-                fprintf(stderr, "failed to create display: %m\n");
-                return EXIT_FAILURE;
-        }
+    display = wl_display_connect(NULL);
+    if (display == NULL) {
+        fprintf(stderr, "failed to create display: %m\n");
+        return EXIT_FAILURE;
+    }
 
-        struct wl_registry *registry = wl_display_get_registry(display);
-        wl_registry_add_listener(registry, &registry_listener, NULL);
+    struct wl_registry *registry = wl_display_get_registry(display);
+    wl_registry_add_listener(registry, &registry_listener, NULL);
     sync_wayland();
 
     check_has_protos();
@@ -605,5 +606,5 @@ int main(int argc, char *argv[])
     for (auto& buffer : buffers)
         wl_buffer_destroy(buffer.wl_buffer);
 
-        return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The source previously mixed tabs and spaces. This normalized the source to
spaces. Tabs are fine too, but not both!