### PR TITLE
Add command line argument to specify the codec

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -22,7 +22,7 @@ public :
 
 static FFmpegInitialize ffmpegInitialize;
 
-FrameWriter::FrameWriter(const string& filename, int width_, int height_, InputFormat format) :
+FrameWriter::FrameWriter(const string& filename, const std::string& codec_name, int width_, int height_, InputFormat format) :
     width(width_), height(height_)
 {
     switch (format)
@@ -45,11 +45,13 @@ FrameWriter::FrameWriter(const string& filename, int width_, int height_, InputF
     avformat_alloc_output_context2(&fc, NULL, NULL, filename.c_str());
 
     // Setting up the codec.
-    AVCodec* codec = avcodec_find_encoder_by_name("libx264");
+    AVCodec* codec = avcodec_find_encoder_by_name(codec_name.c_str());
     AVDictionary* opt = NULL;
-    av_dict_set(&opt, "tune", "zerolatency", 0);
-    av_dict_set(&opt, "preset", "ultrafast", 0);
-    av_dict_set(&opt, "crf", "20", 0);
+    if (!codec_name.compare("libx264")) {
+        av_dict_set(&opt, "tune", "zerolatency", 0);
+        av_dict_set(&opt, "preset", "ultrafast", 0);
+        av_dict_set(&opt, "crf", "20", 0);
+    }
 
     stream = avformat_new_stream(fc, codec);
     c = stream->codec;

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -40,7 +40,7 @@ class FrameWriter
     void finish_frame();
 
 public :
-    FrameWriter(const std::string& filename,
+    FrameWriter(const std::string& filename, const std::string& codec,
         int width, int height, InputFormat format);
     void add_frame(const uint8_t* pixels, int msec, bool y_invert);
     ~FrameWriter();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -272,7 +272,7 @@ static InputFormat get_input_format(wf_buffer& buffer)
     std::exit(0);
 }
 
-static void write_loop(std::string name, int32_t width, int32_t height)
+static void write_loop(std::string name, std::string codec, int32_t width, int32_t height)
 {
     /* Ignore SIGINT, main loop is responsible for the exit_main_loop signal */
     sigset_t sigset;
@@ -296,7 +296,7 @@ static void write_loop(std::string name, int32_t width, int32_t height)
         if (!writer)
         {
             writer = std::unique_ptr<FrameWriter> (
-                new FrameWriter(name, width, height,
+                new FrameWriter(name, codec, width, height,
                     get_input_format(buffer)));
         }
 
@@ -443,17 +443,19 @@ int main(int argc, char *argv[])
 {
     std::string file = "recording.mp4";
     std::string cmdline_output = "invalid";
+    std::string codec = "libx264";
     capture_region selected_region{};
 
     struct option opts[] = {
         { "output",          required_argument, NULL, 'o' },
         { "file",            required_argument, NULL, 'f' },
         { "geometry",        required_argument, NULL, 'g' },
+        { "codec",           required_argument, NULL, 'c' },
         { 0,                 0,                 NULL,  0  }
     };
 
     int c, i;
-    while((c = getopt_long(argc, argv, "o:f:g:", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:g:c:", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -467,6 +469,10 @@ int main(int argc, char *argv[])
 
             case 'g':
                 selected_region.set_from_string(optarg);
+                break;
+
+            case 'c':
+                codec = optarg;
                 break;
 
             default:
@@ -582,7 +588,7 @@ int main(int argc, char *argv[])
         {
             int width = buffer.width, height = buffer.height;
             writer_thread = std::thread([=] () {
-                write_loop(file, width, height);
+                write_loop(file, codec, width, height);
             });
 
             spawned_thread = true;


### PR DESCRIPTION
An attempt to address https://github.com/ammen99/wf-recorder/issues/2

Usage: `wf-recorder -c libx264` (default) or other ffmpeg codecs.

It works for me with the nvenc codecs, e.g. `wf-recorder -c nvenc_h264` or `wf-recorder -v nvenc_hevc`. In my case I have to do `optirun wf-recorder`, since I have nvidia optimus graphics and bumblebee

### Issues
- So far it does not work with the VAAPI encoders for Intel GPUs (which are more common, less power hungry, and don't require closed source drivers). I think this is because they require an ffmpeg hardware device to be initialised, and maybe also a different pixel format and filters to upload the frames to the device. See https://trac.ffmpeg.org/wiki/Hardware/VAAPI for command line examples. It works with wlstream: https://github.com/atomnuker/wlstream/blob/master/src/wlstream.c
- With nvenc, one of my CPU cores is maxed out when capturing
- the `crf` option is not valid for nvenc or vaapi encoders - so a different method is needed to control bitrate/quality