### PR TITLE
Add to-yuv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ To use gpu encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU 
 ```
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
+Some drivers report support for rgb0 data for vaapi input but really only support yuv. In this case, use the `-t` or `--to-yuv` option in addition to the vaapi options to convert the data in software before sending it to the gpu.

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -45,6 +45,8 @@ struct FrameWriterParams
 
     bool enable_audio;
     bool enable_ffmpeg_debug_output;
+
+    bool to_yuv;
 };
 
 class FrameWriter
@@ -64,7 +66,7 @@ class FrameWriter
     AVPixelFormat choose_sw_format(AVCodec *codec);
     AVPixelFormat get_input_format();
     void init_hw_accel();
-    void init_sws();
+    void init_sws(AVPixelFormat format);
     void init_codecs();
     void init_video_stream();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -488,6 +488,7 @@ int main(int argc, char *argv[])
     params.codec = DEFAULT_CODEC;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
+    params.to_yuv = false;
 
     PulseReaderParams pulseParams;
 
@@ -505,13 +506,14 @@ int main(int argc, char *argv[])
         { "device",          required_argument, NULL, 'd' },
         { "log",             no_argument,       NULL, 'l' },
         { "audio",           optional_argument, NULL, 'a' },
+        { "to-yuv",          no_argument,       NULL, 't' },
         { 0,                 0,                 NULL,  0  }
     };
 
     int c, i;
     std::string param;
     size_t pos;
-    while((c = getopt_long(argc, argv, "o:f:g:c:p:d:la::", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:g:c:p:d:la::t::", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -542,6 +544,10 @@ int main(int argc, char *argv[])
             case 'a':
                 params.enable_audio = true;
                 pulseParams.audio_source = optarg ? strdup(optarg) : NULL;
+                break;
+
+            case 't':
+                params.to_yuv = true;
                 break;
 
             case 'p':


### PR DESCRIPTION
Add a new option --to-yuv (or -t) which converts each frame from rgb0/bgr0 to nv12/yuv420
in software using sws_scale(), before sending to the gpu for encoding. This is needed for
some drivers like the radeonsi vaapi driver, which crashes when fed rgb0 data for encoding.
See fdo bug #110719. Fixes #13.