### PR TITLE
Add OpenCL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
 Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-t` or `--force-yuv` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the gpu.
 
-The `-t` option attempts to use OpenCL if wf-recorder was built with OpenCL support and `-e` or `--opencl` is specified, even without vaapi gpu encoding. Use `-e#` or `--opencl=#` to use a specific OpenCL device, where `#` is one of the devices listed.
+The `-e` option attempts to use OpenCL if wf-recorder was built with OpenCL support and `-t` or `--force-yuv` is specified, even without vaapi gpu encoding. Use `-e#` or `--opencl=#` to use a specific OpenCL device, where `#` is one of the devices listed.

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
 Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-t` or `--force-yuv` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the gpu.
 
-The `-t` option attempts to use OpenCL if wf-recorder was built with OpenCL support and `-e` or `--opencl` is specified, even without vaapi gpu encoding.
+The `-t` option attempts to use OpenCL if wf-recorder was built with OpenCL support and `-e` or `--opencl` is specified, even without vaapi gpu encoding. Use `-e#` or `--opencl=#` to use a specific OpenCL device, where `#` is one of the devices listed.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ To use gpu encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU 
 ```
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
-Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-r` or `--convert-rgb` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the gpu.
+Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-t` or `--force-yuv` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the gpu.
 
-The `-r` option attempts to use OpenCL if wf-recorder was built with OpenCL support, even without vaapi gpu encoding.
+The `-t` option attempts to use OpenCL if wf-recorder was built with OpenCL support and `-e` or `--opencl` is specified, even without vaapi gpu encoding.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ To use gpu encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU 
 ```
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
-Some drivers report support for rgb0 data for vaapi input but really only support yuv. In this case, use the `-t` or `--to-yuv` option in addition to the vaapi options to convert the data in software before sending it to the gpu.
+Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats like nv12. In this case, use the `-t` or `--to-nv12` option in addition to the vaapi options to convert the data in software before sending it to the gpu.
 
 The `-t` option attempts to use OpenCL if wf-recorder was built with OpenCL support, even without vaapi gpu encoding.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ To use gpu encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU 
 ```
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
-Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats like nv12. In this case, use the `-t` or `--to-nv12` option in addition to the vaapi options to convert the data in software before sending it to the gpu.
+Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-r` or `--convert-rgb` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the gpu.
 
-The `-t` option attempts to use OpenCL if wf-recorder was built with OpenCL support, even without vaapi gpu encoding.
+The `-r` option attempts to use OpenCL if wf-recorder was built with OpenCL support, even without vaapi gpu encoding.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ To use gpu encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU 
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
 Some drivers report support for rgb0 data for vaapi input but really only support yuv. In this case, use the `-t` or `--to-yuv` option in addition to the vaapi options to convert the data in software before sending it to the gpu.
+
+The `-t` option attempts to use OpenCL if wf-recorder was built with OpenCL support, even without vaapi gpu encoding.

--- a/config.h.in
+++ b/config.h.in
@@ -1,3 +1,4 @@
 #pragma once
 
 #define DEFAULT_CODEC "@default_codec@"
+#mesondefine HAVE_OPENCL

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
 	'cpp',
 	version: '0.1',
 	license: 'MIT',
-	meson_version: '>=0.43.0',
+	meson_version: '>=0.47.0',
 	default_options: [
 		'cpp_std=c++11',
         'c_std=c11',
@@ -17,16 +17,25 @@ conf_data = configuration_data()
 
 conf_data.set('default_codec', get_option('default_codec'))
 
-configure_file(input: 'config.h.in',
-               output: 'config.h',
-               configuration: conf_data)
-
 include_directories(['.'])
 
 add_project_arguments(['-Wno-deprecated-declarations'], language: 'cpp')
 
+project_sources = ['src/frame-writer.cpp', 'src/main.cpp', 'src/pulse.cpp', 'src/averr.c']
+
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols')
+
+opencl = dependency('OpenCL', required : get_option('opencl'))
+
+if opencl.found()
+    conf_data.set('HAVE_OPENCL', true)
+    project_sources += 'src/opencl.cpp'
+endif
+
+configure_file(input: 'config.h.in',
+               output: 'config.h',
+               configuration: conf_data)
 
 libavutil = dependency('libavutil')
 libavcodec = dependency('libavcodec')
@@ -64,6 +73,6 @@ if scdoc.found()
 endif
 
 subdir('proto')
-executable('wf-recorder', ['src/frame-writer.cpp', 'src/main.cpp', 'src/pulse.cpp', 'src/averr.c'],
-        dependencies: [wayland_client, wayland_protos, libavutil, libavcodec, libavformat, wf_protos, sws, threads, pulse, swr],
+executable('wf-recorder', project_sources,
+        dependencies: [wayland_client, wayland_protos, libavutil, libavcodec, libavformat, wf_protos, sws, threads, pulse, swr, opencl],
         install: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('default_codec', type: 'string', value: 'libx264', description: 'Codec that will be used by default')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
+option('opencl', type: 'feature', value: 'auto', description: 'Enable OpenCL')

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -385,10 +385,9 @@ void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
     if (hw_device_context)
     {
 #ifdef HAVE_OPENCL
-        uint32_t *local_yuv_buffer = NULL;
         if (params.to_yuv)
         {
-            int ret = opencl->do_frame(pixels, &local_yuv_buffer, encoder_frame, get_input_format(), y_invert);
+            int ret = opencl->do_frame(pixels, encoder_frame, get_input_format(), y_invert);
 
             if (ret)
                 sws_scale(swsCtx, &formatted_pixels, stride, 0, params.height,
@@ -409,10 +408,6 @@ void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
         }
 
         output_frame = &hw_frame;
-
-#ifdef HAVE_OPENCL
-	free(local_yuv_buffer);
-#endif
     } else if(get_input_format() == videoCodecCtx->pix_fmt)
     {
         output_frame = &encoder_frame;

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -10,14 +10,6 @@
 #include <cstring>
 #include "averr.h"
 
-#include "config.h"
-
-#ifdef HAVE_OPENCL
-#include "opencl.hpp"
-
-std::unique_ptr<OpenCL> opencl;
-#endif
-
 #define FPS 60
 #define AUDIO_RATE 44100
 
@@ -158,11 +150,6 @@ void FrameWriter::init_video_stream()
     videoCodecCtx->width = params.width;
     videoCodecCtx->height = params.height;
     videoCodecCtx->time_base = (AVRational){ 1, FPS };
-
-#ifdef HAVE_OPENCL
-     if (params.opencl && params.force_yuv)
-         opencl = std::unique_ptr<OpenCL> (new OpenCL(params.width, params.height));
-#endif
 
     if (params.codec.find("vaapi") != std::string::npos)
     {

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -122,8 +122,8 @@ AVPixelFormat FrameWriter::get_input_format()
 AVPixelFormat FrameWriter::choose_sw_format(AVCodec *codec)
 {
 #ifdef HAVE_OPENCL
-    /* First case: the user preference is to convert the rgb data to yuv */
-    if (params.to_yuv && is_fmt_supported(AV_PIX_FMT_NV12, codec->pix_fmts))
+    /* First case: the user preference is to convert the rgb data to nv12 */
+    if (params.to_nv12 && is_fmt_supported(AV_PIX_FMT_NV12, codec->pix_fmts))
         return AV_PIX_FMT_NV12;
 #endif
     /* Second case: if the codec supports getting the appropriate RGB format
@@ -165,7 +165,7 @@ void FrameWriter::init_video_stream()
     videoCodecCtx->time_base = (AVRational){ 1, FPS };
 
 #ifdef HAVE_OPENCL
-     if (params.to_yuv)
+     if (params.to_nv12)
          opencl = std::unique_ptr<OpenCL> (new OpenCL(params.width, params.height));
 #endif
 
@@ -175,7 +175,7 @@ void FrameWriter::init_video_stream()
         init_hw_accel();
         videoCodecCtx->hw_frames_ctx = av_buffer_ref(hw_frame_context);
 
-        if (params.to_yuv)
+        if (params.to_nv12)
             init_sws(AV_PIX_FMT_NV12);
     } else
     {
@@ -343,7 +343,7 @@ FrameWriter::FrameWriter(const FrameWriterParams& _params) :
 
     encoder_frame = av_frame_alloc();
     if (hw_device_context) {
-        encoder_frame->format = params.to_yuv ? AV_PIX_FMT_NV12 : get_input_format();
+        encoder_frame->format = params.to_nv12 ? AV_PIX_FMT_NV12 : get_input_format();
     } else {
         encoder_frame->format = videoCodecCtx->pix_fmt;
     }
@@ -389,7 +389,7 @@ void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
     if (hw_device_context)
     {
 #ifdef HAVE_OPENCL
-        if (params.to_yuv)
+        if (params.to_nv12)
         {
             if (opencl->do_frame(pixels, encoder_frame, get_input_format(), y_invert))
             {
@@ -399,7 +399,7 @@ void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
             }
         }
 #else
-        if (params.to_yuv)
+        if (params.to_nv12)
         {
             sws_scale(swsCtx, &formatted_pixels, stride, 0, params.height,
                 encoder_frame->data, encoder_frame->linesize);
@@ -424,7 +424,7 @@ void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
     } else
     {
 #ifdef HAVE_OPENCL
-        if (params.to_yuv)
+        if (params.to_nv12)
         {
             if (opencl->do_frame(pixels, encoder_frame, get_input_format(), y_invert))
             {

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -392,13 +392,19 @@ void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
                     encoder_frame->data, encoder_frame->linesize);
             }
         }
+        else
 #else
         if (params.convert_rgb)
         {
             sws_scale(swsCtx, &formatted_pixels, stride, 0, params.height,
                 encoder_frame->data, encoder_frame->linesize);
         }
+        else
 #endif
+        {
+            encoder_frame->data[0] = (uint8_t*) formatted_pixels;
+            encoder_frame->linesize[0] = stride[0];
+        }
 
         if (av_hwframe_transfer_data(hw_frame, encoder_frame, 0))
         {

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -379,14 +379,12 @@ void FrameWriter::convert_pixels_to_yuv(const uint8_t *pixels,
         int r = opencl->do_frame(pixels, encoder_frame,
             get_input_format(), y_invert);
 
-        std::cout << "convert via opencl" << std::endl;
         converted_with_opencl = (r == 0);
     }
 #endif
 
     if (!converted_with_opencl)
     {
-        std::cout << "convert with sws" << std::endl;
         sws_scale(swsCtx, &formatted_pixels, stride, 0, params.height,
             encoder_frame->data, encoder_frame->linesize);
     }

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -334,6 +334,11 @@ FrameWriter::FrameWriter(const FrameWriterParams& _params) :
         std::exit(-1);
     }
 
+#ifndef HAVE_OPENCL
+    if (params.opencl)
+        std::cerr << "This version of wf-recorder was built without OpenCL support. Ignoring OpenCL option." << std::endl;
+#endif
+
     init_codecs();
 
     encoder_frame = av_frame_alloc();
@@ -381,6 +386,9 @@ void FrameWriter::convert_pixels_to_yuv(const uint8_t *pixels,
 
         converted_with_opencl = (r == 0);
     }
+#else
+    /* Silence compiler warning when opencl is disabled */
+    (void)(y_invert);
 #endif
 
     if (!converted_with_opencl)

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -401,6 +401,7 @@ void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
 #else
         if (params.to_nv12)
         {
+            encoder_frame->format = AV_PIX_FMT_YUV420P;
             sws_scale(swsCtx, &formatted_pixels, stride, 0, params.height,
                 encoder_frame->data, encoder_frame->linesize);
         }

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -429,10 +429,12 @@ void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
                     encoder_frame->data, encoder_frame->linesize);
             }
         }
-#else
-        sws_scale(swsCtx, &formatted_pixels, stride, 0, params.height,
-            encoder_frame->data, encoder_frame->linesize);
+        else
 #endif
+        {
+            sws_scale(swsCtx, &formatted_pixels, stride, 0, params.height,
+                encoder_frame->data, encoder_frame->linesize);
+        }
         /* Force ffmpeg to create a copy of the frame, if the codec needs it */
         saved_buf0 = encoder_frame->buf[0];
         encoder_frame->buf[0] = NULL;

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -176,7 +176,13 @@ void FrameWriter::init_video_stream()
         videoCodecCtx->hw_frames_ctx = av_buffer_ref(hw_frame_context);
 
         if (params.convert_rgb)
+        {
+#ifdef HAVE_OPENCL
             init_sws(AV_PIX_FMT_NV12);
+#else
+            init_sws(AV_PIX_FMT_YUV420P);
+#endif
+        }
     } else
     {
         videoCodecCtx->pix_fmt = choose_sw_format(codec);
@@ -343,7 +349,13 @@ FrameWriter::FrameWriter(const FrameWriterParams& _params) :
 
     encoder_frame = av_frame_alloc();
     if (hw_device_context) {
-        encoder_frame->format = params.convert_rgb ? AV_PIX_FMT_NV12 : get_input_format();
+        encoder_frame->format = params.convert_rgb ?
+#ifdef HAVE_OPENCL
+            AV_PIX_FMT_NV12
+#else
+            AV_PIX_FMT_YUV420P
+#endif
+            : get_input_format();
     } else {
         encoder_frame->format = videoCodecCtx->pix_fmt;
     }

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -345,14 +345,7 @@ FrameWriter::FrameWriter(const FrameWriterParams& _params) :
     if (hw_device_context) {
         encoder_frame->format = params.convert_rgb ? AV_PIX_FMT_NV12 : get_input_format();
     } else {
-#ifdef HAVE_OPENCL
-        if (params.convert_rgb)
-            encoder_frame->format = opencl->ret ? videoCodecCtx->pix_fmt : AV_PIX_FMT_NV12;
-        else
-            encoder_frame->format = videoCodecCtx->pix_fmt;
-#else
         encoder_frame->format = videoCodecCtx->pix_fmt;
-#endif
     }
     encoder_frame->width = params.width;
     encoder_frame->height = params.height;

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -46,7 +46,7 @@ struct FrameWriterParams
     bool enable_audio;
     bool enable_ffmpeg_debug_output;
 
-    bool to_nv12;
+    bool convert_rgb;
 };
 
 class FrameWriter

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -23,6 +23,14 @@ extern "C"
     #include <libavutil/opt.h>
 }
 
+#include "config.h"
+
+#ifdef HAVE_OPENCL
+#include <memory>
+#include "opencl.hpp"
+class OpenCL;
+#endif
+
 enum InputFormat
 {
      INPUT_FORMAT_BGR0,
@@ -48,6 +56,7 @@ struct FrameWriterParams
 
     bool opencl;
     bool force_yuv;
+    int opencl_device;
 };
 
 class FrameWriter
@@ -100,6 +109,10 @@ public :
     /* Buffer must have size get_audio_buffer_size() */
     void add_audio(const void* buffer);
     size_t get_audio_buffer_size();
+
+#ifdef HAVE_OPENCL
+    std::unique_ptr<OpenCL> opencl;
+#endif
 
     ~FrameWriter();
 };

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -46,8 +46,8 @@ struct FrameWriterParams
     bool enable_audio;
     bool enable_ffmpeg_debug_output;
 
-    bool no_opencl;
-    bool convert_rgb;
+    bool opencl;
+    bool force_yuv;
 };
 
 class FrameWriter

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -74,6 +74,16 @@ class FrameWriter
     AVFrame *encoder_frame = NULL;
     AVFrame *hw_frame = NULL;
 
+    /**
+     * Convert the given pixels to YUV and store in encoder_frame.
+     * Calls OpenCL if it is enabled.
+     *
+     * @param formatted_pixels contains the same data as pixels but y-inverted
+     * if the input format requires y-inversion.
+     */
+    void convert_pixels_to_yuv(const uint8_t *pixels,
+        const uint8_t *formatted_pixels, int stride[]);
+
     SwrContext *swrCtx;
     AVStream *audioStream;
     AVCodecContext *audioCodecCtx;

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -46,7 +46,7 @@ struct FrameWriterParams
     bool enable_audio;
     bool enable_ffmpeg_debug_output;
 
-    bool to_yuv;
+    bool to_nv12;
 };
 
 class FrameWriter

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -46,6 +46,7 @@ struct FrameWriterParams
     bool enable_audio;
     bool enable_ffmpeg_debug_output;
 
+    bool no_opencl;
     bool convert_rgb;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -512,8 +512,6 @@ With no FILE, start recording the current screen.
   -d, --device              Selects the device to use when encoding the video
                             Some drivers report support for rgb0 data for vaapi input but
                             really only support yuv.
-                            Use the -t or --to-yuv option in addition to the vaapi options to
-                            convert the data in software, before sending it to the gpu.
 
   -f <filename>.ext         By using the -f option the output file will have the name :
                             filename.ext and the file format will be determined by provided

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -555,7 +555,7 @@ int main(int argc, char *argv[])
     params.codec = DEFAULT_CODEC;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
-    params.to_nv12 = false;
+    params.convert_rgb = false;
 
     PulseReaderParams pulseParams;
 
@@ -575,13 +575,14 @@ int main(int argc, char *argv[])
         { "audio",           optional_argument, NULL, 'a' },
         { "help",            no_argument,       NULL, 'h' },
         { "to-nv12",         no_argument,       NULL, 't' },
+        { "convert-rgb",     no_argument,       NULL, 'r' },
         { 0,                 0,                 NULL,  0  }
     };
 
     int c, i;
     std::string param;
     size_t pos;
-    while((c = getopt_long(argc, argv, "o:f:g:c:p:d:la::t::h", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:g:c:p:d:la::t::r::h", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -614,8 +615,8 @@ int main(int argc, char *argv[])
                 pulseParams.audio_source = optarg ? strdup(optarg) : NULL;
                 break;
 
-            case 't':
-                params.to_nv12 = true;
+            case 'r':
+                params.convert_rgb = true;
                 break;
 
             case 'h':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -502,7 +502,7 @@ With no FILE, start recording the current screen.
 
   -a, --audio [DEVICE]      Starts recording the screen with audio.
                             [DEVICE] argument is optional.
-                            In case you want to specify the pulseaudio device which will capture 
+                            In case you want to specify the pulseaudio device which will capture
                             the audio, you can run this command with the name of that device.
                             You can find your device by running: pactl list sinks | grep Name
 
@@ -533,14 +533,14 @@ With no FILE, start recording the current screen.
   -p, --codec-param         Change the codec parameters.
                             -p <option_name>=<option_value>
 
-  -t, to-yuv                Use the -t or --to-yuv option in addition to the vaapi options to
-                            convert the data in software, before sending it to the gpu.\n\n
+  -t, force-yuv             Use the -t or --force-yuv option to force conversion of the data to
+                            yuv format, before sending it to the gpu.\n\n
 Examples:
 
   Video Only:
 
   - wf-recorder                         Records the video. Use Ctrl+C to stop recording.
-                                        The video file will be stored as recording.mp4 in the 
+                                        The video file will be stored as recording.mp4 in the
                                         current working directory.
 
   - wf-recorder -f <filename>.ext       Records the video. Use Ctrl+C to stop recording.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -555,8 +555,8 @@ int main(int argc, char *argv[])
     params.codec = DEFAULT_CODEC;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
-    params.convert_rgb = false;
-    params.no_opencl = false;
+    params.force_yuv = false;
+    params.opencl = false;
 
     PulseReaderParams pulseParams;
 
@@ -575,16 +575,15 @@ int main(int argc, char *argv[])
         { "log",             no_argument,       NULL, 'l' },
         { "audio",           optional_argument, NULL, 'a' },
         { "help",            no_argument,       NULL, 'h' },
-        { "to-nv12",         no_argument,       NULL, 't' },
-        { "convert-rgb",     no_argument,       NULL, 'r' },
-        { "no-opencl",       no_argument,       NULL, 'n' },
+        { "force-yuv",       no_argument,       NULL, 't' },
+        { "opencl",          no_argument,       NULL, 'e' },
         { 0,                 0,                 NULL,  0  }
     };
 
     int c, i;
     std::string param;
     size_t pos;
-    while((c = getopt_long(argc, argv, "o:f:g:c:p:d:la::t::r::n::h", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:g:c:p:d:la::t::e::h", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -617,16 +616,16 @@ int main(int argc, char *argv[])
                 pulseParams.audio_source = optarg ? strdup(optarg) : NULL;
                 break;
 
-            case 'r':
-                params.convert_rgb = true;
+            case 't':
+                params.force_yuv = true;
                 break;
 
             case 'h':
                 help();
                 break;
 
-            case 'n':
-                params.no_opencl = true;
+            case 'e':
+                params.opencl = true;
                 break;
 
             case 'p':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -555,7 +555,7 @@ int main(int argc, char *argv[])
     params.codec = DEFAULT_CODEC;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
-    params.to_yuv = false;
+    params.to_nv12 = false;
 
     PulseReaderParams pulseParams;
 
@@ -573,8 +573,8 @@ int main(int argc, char *argv[])
         { "device",          required_argument, NULL, 'd' },
         { "log",             no_argument,       NULL, 'l' },
         { "audio",           optional_argument, NULL, 'a' },
-        { "to-yuv",          no_argument,       NULL, 't' },
         { "help",            no_argument,       NULL, 'h' },
+        { "to-nv12",         no_argument,       NULL, 't' },
         { 0,                 0,                 NULL,  0  }
     };
 
@@ -615,7 +615,7 @@ int main(int argc, char *argv[])
                 break;
 
             case 't':
-                params.to_yuv = true;
+                params.to_nv12 = true;
                 break;
 
             case 'h':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -556,6 +556,7 @@ int main(int argc, char *argv[])
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
     params.convert_rgb = false;
+    params.no_opencl = false;
 
     PulseReaderParams pulseParams;
 
@@ -576,13 +577,14 @@ int main(int argc, char *argv[])
         { "help",            no_argument,       NULL, 'h' },
         { "to-nv12",         no_argument,       NULL, 't' },
         { "convert-rgb",     no_argument,       NULL, 'r' },
+        { "no-opencl",       no_argument,       NULL, 'n' },
         { 0,                 0,                 NULL,  0  }
     };
 
     int c, i;
     std::string param;
     size_t pos;
-    while((c = getopt_long(argc, argv, "o:f:g:c:p:d:la::t::r::h", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:g:c:p:d:la::t::r::n::h", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -621,6 +623,10 @@ int main(int argc, char *argv[])
 
             case 'h':
                 help();
+                break;
+
+            case 'n':
+                params.no_opencl = true;
                 break;
 
             case 'p':

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -450,7 +450,6 @@ OpenCL::~OpenCL()
     clReleaseKernel(kernel);
     clReleaseProgram(program);
     clReleaseMemObject(yuv420_buffer);
-    /* Causes crash */
-    //clReleaseCommandQueue(command_queue);
+    clReleaseCommandQueue(command_queue);
     clReleaseContext(context);
 }

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -65,9 +65,9 @@ __kernel void rgbx_2_yuv (__global  unsigned int *sourceImage,						\n\
         }												\n\
     }													\n\
 													\n\
-    destImage [(posY * yuvStride) + posX] = Y;								\n\
+    destImage[(posY * yuvStride) + posX] = Y;								\n\
     if (!(posY % 2))											\n\
-        destImage [(yuvStride * srcHeight) + ((posY >> 1) * yuvStride) + posX] = UV;			\n\
+        destImage[(yuvStride * srcHeight) + ((posY >> 1) * yuvStride) + posX] = UV;			\n\
     return;												\n\
 }													\n\
 ";

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -3,8 +3,8 @@
 #include "opencl.hpp"
 
 static char const *cl_source_str = "									\n\
-__kernel void rgbx_2_yuv (__global  unsigned int * sourceImage,						\n\
-                          __global unsigned int * destImage,						\n\
+__kernel void rgbx_2_yuv (__global  unsigned int *sourceImage,						\n\
+                          __global unsigned int *destImage,						\n\
                           unsigned int srcWidth,							\n\
                           unsigned int srcHeight,							\n\
                           short rgb0)									\n\
@@ -23,10 +23,10 @@ __kernel void rgbx_2_yuv (__global  unsigned int * sourceImage,						\n\
 													\n\
     posSrc = (posY * srcWidth) + (posX * 4);								\n\
 													\n\
-    pixels[0] = sourceImage [posSrc + 0];								\n\
-    pixels[1] = sourceImage [posSrc + 1];								\n\
-    pixels[2] = sourceImage [posSrc + 2];								\n\
-    pixels[3] = sourceImage [posSrc + 3];								\n\
+    pixels[0] = sourceImage[posSrc + 0];								\n\
+    pixels[1] = sourceImage[posSrc + 1];								\n\
+    pixels[2] = sourceImage[posSrc + 2];								\n\
+    pixels[3] = sourceImage[posSrc + 3];								\n\
 													\n\
     for (i = 0; i < 4; i++)										\n\
     {													\n\
@@ -69,6 +69,12 @@ OpenCL::OpenCL(int _width, int _height)
 {
     width = _width;
     height = _height;
+
+    if (width % 4)
+        std::cerr << "OpenCL WARN: width (" << width << ") not evenly divisible by 4. This might not work." << std::endl;
+
+    if (height % 2)
+        std::cerr << "OpenCL WARN: height (" << height << ") not evenly divisible by 2. This might not work." << std::endl;
 
     // Get platform and device information
     cl_platform_id platform_id = NULL;

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -215,6 +215,13 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
         return -1;
     }
 
+    ret |= clReleaseMemObject(rgb_buffer);
+    if (ret)
+    {
+        std::cerr << "clReleaseMemObject failed!" << std::endl;
+        return -1;
+    }
+
     formatted_pixels = (uint8_t *) local_nv12_buffer;
     if (y_invert)
         formatted_pixels += width * (height - 1);
@@ -231,8 +238,6 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     encoder_frame->linesize[0] = -width;
     encoder_frame->linesize[1] = -width;
 
-    clReleaseMemObject(rgb_buffer);
-
     return ret;
 }
 
@@ -242,9 +247,9 @@ OpenCL::~OpenCL()
     clFinish(command_queue);
     clReleaseKernel(kernel);
     clReleaseProgram(program);
-    clReleaseMemObject(rgb_buffer);
     clReleaseMemObject(nv12_buffer);
-    clReleaseCommandQueue(command_queue);
+    /* Causes crash */
+    //clReleaseCommandQueue(command_queue);
     clReleaseContext(context);
     free(local_nv12_buffer);
 }

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -219,7 +219,7 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     if (ret)
     {
         std::cerr << "clCreateBuffer (rgb) failed!" << std::endl;
-        return -1;
+        return ret;
     }
 
     ret |= clSetKernelArg ( kernel, 0, sizeof(cl_mem), &rgb_buffer );
@@ -230,7 +230,7 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     if (ret)
     {
         std::cerr << "clSetKernelArg failed!" << std::endl;
-        return -1;
+        return ret;
     }
 
     const size_t global_ws[] = {halfWidth, halfHeight};
@@ -238,7 +238,7 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     if (ret)
     {
         std::cerr << "clEnqueueNDRangeKernel failed!" << std::endl;
-        return -1;
+        return ret;
     }
 
     // Read yuv420 buffer from gpu
@@ -247,14 +247,14 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     if (ret)
     {
         std::cerr << "clEnqueueReadBuffer failed!" << std::endl;
-        return -1;
+        return ret;
     }
 
     ret |= clReleaseMemObject(rgb_buffer);
     if (ret)
     {
         std::cerr << "clReleaseMemObject failed!" << std::endl;
-        return -1;
+        return ret;
     }
 
     formatted_pixels = local_yuv420_buffer;

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -10,33 +10,41 @@
 
 
 static char const *cl_source_str = "									\n\
-__kernel void rgbx_2_nv12 (__global  unsigned int *sourceImage,						\n\
-                           __global unsigned int *destImage,						\n\
-                           unsigned int srcWidth,							\n\
-                           unsigned int srcHeight,							\n\
-                           short rgb0)									\n\
+__kernel void rgbx_2_yuv420 (__global unsigned int  *sourceImage,					\n\
+                             __global unsigned char *destImage,						\n\
+                             unsigned int srcWidth,							\n\
+                             unsigned int srcHeight,							\n\
+                             short rgb0)								\n\
 {													\n\
-    int i,j;												\n\
-    unsigned int pixels[4];										\n\
-    unsigned int posSrc, RGB, Y = 0, UV = 0, ValueY, ValueU, ValueV;					\n\
+    int i, d;												\n\
+    unsigned int pixels[4], posSrc[2];									\n\
+    unsigned int RGB, ValueY, ValueU, ValueV, c1, c2, c3;						\n\
     unsigned char r, g, b;										\n\
 													\n\
     unsigned int posX = get_global_id(0);								\n\
     unsigned int posY = get_global_id(1);								\n\
-    unsigned int nv12Stride = srcWidth >> 2;								\n\
 													\n\
-    if (posX >= nv12Stride || posY >= srcHeight)							\n\
+    unsigned int halfWidth = ((srcWidth + 1) >> 1);							\n\
+    unsigned int halfHeight = ((srcHeight + 1) >> 1);							\n\
+													\n\
+    if (posX >= halfWidth || posY >= halfHeight)							\n\
         return;												\n\
 													\n\
-    posSrc = (posY * srcWidth) + (posX * 4);								\n\
+    posSrc[0] = ((posY * 2) * srcWidth) + (posX * 2);							\n\
+    posSrc[1] = (((posY * 2) + 1) * srcWidth) + (posX * 2);						\n\
 													\n\
-    pixels[0] = sourceImage[posSrc + 0];								\n\
-    pixels[1] = sourceImage[posSrc + 1];								\n\
-    pixels[2] = sourceImage[posSrc + 2];								\n\
-    pixels[3] = sourceImage[posSrc + 3];								\n\
+    pixels[0] = sourceImage[posSrc[0] + 0];								\n\
+    pixels[1] = sourceImage[posSrc[0] + 1];								\n\
+    pixels[2] = sourceImage[posSrc[1] + 0];								\n\
+    pixels[3] = sourceImage[posSrc[1] + 1];								\n\
 													\n\
     for (i = 0; i < 4; i++)										\n\
     {													\n\
+        if (i == 1 && (posX + 1) > halfWidth)								\n\
+            continue;											\n\
+        if (i > 1 && ((posSrc[1] + ((i - 1) >> 1)) >= (srcWidth * srcHeight)))				\n\
+            break;											\n\
+													\n\
         RGB = pixels[i];										\n\
         if (rgb0)											\n\
         {												\n\
@@ -47,27 +55,58 @@ __kernel void rgbx_2_nv12 (__global  unsigned int *sourceImage,						\n\
             b = (RGB) & 0xff; g = (RGB >> 8) & 0xff; r = (RGB >> 16) & 0xff;				\n\
         }												\n\
 													\n\
-        // Y plane - pack 4 * 8-bit Y's within each 32-bit unit.					\n\
-        // Each 24-bit RGB value is sampled and converted into an					\n\
-        // 8-bit Y value which represent the pixels as grayscale.					\n\
+        // Y plane - pack 1 * 8-bit Y's within each 8-bit unit.						\n\
         ValueY = ((66 * r + 129 * g + 25 * b) >> 8) + 16;						\n\
-        Y |= (ValueY << (i * 8));									\n\
-													\n\
-        // UV plane - pack 1 * 8-bit U and 1 * 8-bit V for each sampled pixel				\n\
-        // In this case the target is nv12 which means we only sample					\n\
-        // every other row and every other pixel in each row						\n\
-        if (!(posY % 2) && !(i % 2))									\n\
+        if (i < 2)											\n\
         {												\n\
-            ValueU = ((-38 * r + -74 * g + 112 * b) >> 8) + 128;					\n\
-            ValueV = ((112 * r - 94 * g - 18 * b) >> 8) + 128;						\n\
-            UV |= (ValueU << (i * 8));									\n\
-            UV |= (ValueV << ((i + 1) * 8));								\n\
+            destImage[((posY * 2) * srcWidth) + (posX * 2) + i] = ValueY;				\n\
+        }												\n\
+        else												\n\
+        {												\n\
+            destImage[(((posY * 2) + 1) * srcWidth) + (posX * 2) + (i - 2)] = ValueY;			\n\
         }												\n\
     }													\n\
 													\n\
-    destImage[(posY * nv12Stride) + posX] = Y;								\n\
-    if (!(posY % 2))											\n\
-        destImage[(nv12Stride * srcHeight) + ((posY >> 1) * nv12Stride) + posX] = UV;			\n\
+    c1 = (pixels[0] & 0xff);										\n\
+    c2 = ((pixels[0] >> 8) & 0xff);									\n\
+    c3 = ((pixels[0] >> 16) & 0xff);									\n\
+    d = 0;												\n\
+    if (posX + 1 == halfWidth)										\n\
+    {													\n\
+        c1 += (pixels[1] & 0xff);									\n\
+        c2 += ((pixels[1] >> 8) & 0xff);								\n\
+        c3 += ((pixels[1] >> 16) & 0xff);								\n\
+        d++;												\n\
+    }													\n\
+    if (posY + 1 == halfHeight)										\n\
+    {													\n\
+        c1 += (pixels[2] & 0xff);									\n\
+        c2 += ((pixels[2] >> 8) & 0xff);								\n\
+        c3 += ((pixels[2] >> 16) & 0xff);								\n\
+        d++;												\n\
+    }													\n\
+    if (posX + 1 == halfWidth && posY + 1 == halfHeight)						\n\
+    {													\n\
+        c1 += (pixels[3] & 0xff);									\n\
+        c2 += ((pixels[3] >> 8) & 0xff);								\n\
+        c3 += ((pixels[3] >> 16) & 0xff);								\n\
+    }													\n\
+    if (rgb0)												\n\
+    {													\n\
+        r = c1 >> d; g = c2 >> d; b = c3 >> d;								\n\
+    }													\n\
+    else //bgr0												\n\
+    {													\n\
+        b = c1 >> d; g = c2 >> d; r = c3 >> d;								\n\
+    }													\n\
+													\n\
+    // UV plane - pack 1 * 8-bit U and 1 * 8-bit V for each 4-pixel average				\n\
+    ValueU = ((-38 * r + -74 * g + 112 * b) >> 8) + 128;						\n\
+    ValueV = ((112 * r - 94 * g - 18 * b) >> 8) + 128;							\n\
+    unsigned int u_offset = (srcWidth * srcHeight) + (posY * halfWidth);				\n\
+    unsigned int v_offset = u_offset + (halfWidth * halfHeight);					\n\
+    destImage[u_offset + posX] = ValueU;								\n\
+    destImage[v_offset + posX] = ValueV;								\n\
     return;												\n\
 }													\n\
 ";
@@ -76,12 +115,6 @@ OpenCL::OpenCL(int _width, int _height)
 {
     width = _width;
     height = _height;
-
-    if (width % 4)
-        std::cerr << "OpenCL WARN: width (" << width << ") not evenly divisible by 4. This might not work." << std::endl;
-
-    if (height % 2)
-        std::cerr << "OpenCL WARN: height (" << height << ") not evenly divisible by 2. This might not work." << std::endl;
 
     // Get platform and device information
     cl_platform_id platform_id = NULL;
@@ -142,33 +175,35 @@ OpenCL::OpenCL(int _width, int _height)
     }
 
     // Create the OpenCL kernel
-    kernel = clCreateKernel(program, "rgbx_2_nv12", &ret);
+    kernel = clCreateKernel(program, "rgbx_2_yuv420", &ret);
     if (ret)
     {
         std::cerr << "clCreateKernel failed!" << std::endl;
         return;
     }
 
+    halfWidth = ((width + 1) >> 1);
+    halfHeight = ((height + 1) >> 1);
     unsigned int frameSize = width * height;
+    unsigned int frameSizeUV = halfWidth * halfHeight;
+
     argbSize = frameSize * 4; // ARGB pixels
 
-    nv12Size = frameSize + (frameSize >> 1); // Y+UV planes
+    yuv420Size = frameSize + frameSizeUV * 2; // Y+UV planes
 
-    nv12Stride = width >> 2; // since we pack 4 RGBs into "one" YYYY
-
-    nv12_buffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, nv12Size * sizeof(uint32_t), 0, &ret);
+    yuv420_buffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, yuv420Size * sizeof(char) * 4, 0, &ret);
     if (ret)
     {
-        std::cerr << "clCreateBuffer (nv12) failure!" << std::endl;
+        std::cerr << "clCreateBuffer (yuv420) failure!" << std::endl;
         return;
     }
 
-    local_nv12_buffer = (uint32_t *) malloc(nv12Size * sizeof(uint32_t));
+    local_yuv420_buffer = (uint8_t *) malloc(yuv420Size * sizeof(uint8_t) * 4);
 
-    if (!local_nv12_buffer)
+    if (!local_yuv420_buffer)
         std::cerr << "malloc failure!" << std::endl;
 
-    std::cout << "Using OpenCL for accelerated RGB to NV12 conversion" << std::endl;
+    std::cout << "Using OpenCL for accelerated RGB to YUV420 conversion" << std::endl;
 }
 
 int
@@ -188,7 +223,7 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     }
 
     ret |= clSetKernelArg ( kernel, 0, sizeof(cl_mem), &rgb_buffer );
-    ret |= clSetKernelArg ( kernel, 1, sizeof(cl_mem), &nv12_buffer );
+    ret |= clSetKernelArg ( kernel, 1, sizeof(cl_mem), &yuv420_buffer );
     ret |= clSetKernelArg ( kernel, 2, sizeof(unsigned int), &width);
     ret |= clSetKernelArg ( kernel, 3, sizeof(unsigned int), &height);
     ret |= clSetKernelArg ( kernel, 4, sizeof(short), &rgb0);
@@ -198,7 +233,7 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
         return -1;
     }
 
-    const size_t global_ws[] = { nv12Stride + (nv12Stride >> 1), size_t(height) };
+    const size_t global_ws[] = {halfWidth, halfHeight};
     ret |= clEnqueueNDRangeKernel(command_queue, kernel, 2, NULL, global_ws, NULL, 0, NULL, NULL);
     if (ret)
     {
@@ -206,9 +241,9 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
         return -1;
     }
 
-    // Read nv12 buffer from gpu
-    ret |= clEnqueueReadBuffer(command_queue, nv12_buffer, CL_TRUE, 0,
-        nv12Size * sizeof(uint32_t), local_nv12_buffer, 0, NULL, NULL);
+    // Read yuv420 buffer from gpu
+    ret |= clEnqueueReadBuffer(command_queue, yuv420_buffer, CL_TRUE, 0,
+        yuv420Size * sizeof(uint8_t) * 4, local_yuv420_buffer, 0, NULL, NULL);
     if (ret)
     {
         std::cerr << "clEnqueueReadBuffer failed!" << std::endl;
@@ -222,21 +257,26 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
         return -1;
     }
 
-    formatted_pixels = (uint8_t *) local_nv12_buffer;
+    formatted_pixels = local_yuv420_buffer;
+
     if (y_invert)
         formatted_pixels += width * (height - 1);
-
     encoder_frame->data[0] = (uint8_t *) formatted_pixels;
 
     if (y_invert)
-        formatted_pixels += width * height >> 1;
+        formatted_pixels += (halfWidth) * (halfHeight - 1) + width;
     else
         formatted_pixels += width * height;
-
     encoder_frame->data[1] = (uint8_t *) formatted_pixels;
 
-    encoder_frame->linesize[0] = -width;
-    encoder_frame->linesize[1] = -width;
+    formatted_pixels += halfWidth * halfHeight;
+    encoder_frame->data[2] = (uint8_t *) formatted_pixels;
+
+    short flip = y_invert ? -1 : 1;
+
+    encoder_frame->linesize[0] = width * flip;
+    encoder_frame->linesize[1] = halfWidth * flip;
+    encoder_frame->linesize[2] = halfWidth * flip;
 
     return ret;
 }
@@ -247,9 +287,9 @@ OpenCL::~OpenCL()
     clFinish(command_queue);
     clReleaseKernel(kernel);
     clReleaseProgram(program);
-    clReleaseMemObject(nv12_buffer);
+    clReleaseMemObject(yuv420_buffer);
     /* Causes crash */
     //clReleaseCommandQueue(command_queue);
     clReleaseContext(context);
-    free(local_nv12_buffer);
+    free(local_yuv420_buffer);
 }

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -1,6 +1,13 @@
+/*
+ * Adapted from an example found here https://stackoverflow.com/questions/4979504/fast-rgb-yuv-conversion-in-opencl
+ * Copyright 2019 Scott Moreau
+ *
+ */
+
 #include <iostream>
 
 #include "opencl.hpp"
+
 
 static char const *cl_source_str = "									\n\
 __kernel void rgbx_2_yuv (__global  unsigned int *sourceImage,						\n\

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -88,7 +88,12 @@ OpenCL::OpenCL(int _width, int _height)
     cl_device_id device_id = NULL;
     cl_uint ret_num_devices;
     cl_uint ret_num_platforms;
-    cl_int ret = clGetPlatformIDs(1, &platform_id, &ret_num_platforms);
+    ret = clGetPlatformIDs(1, &platform_id, &ret_num_platforms);
+    if (ret)
+    {
+        std::cerr << "clGetPlatformIDs failed!" << std::endl;
+        return;
+    }
     ret = clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_DEFAULT, 1,
         &device_id, &ret_num_devices);
     if (ret)

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -271,14 +271,14 @@ OpenCL::init(int _width, int _height)
 
     yuv420Size = frameSize + frameSizeUV * 2; // Y+UV planes
 
-    yuv420_buffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, yuv420Size * sizeof(uint8_t), 0, &ret);
+    yuv420_buffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, yuv420Size * sizeof(uint8_t) * 4, 0, &ret);
     if (ret)
     {
         std::cerr << "clCreateBuffer (yuv420) failure!" << std::endl;
         return ret;
     }
 
-    local_yuv420_buffer = (uint8_t *) malloc(yuv420Size * sizeof(uint8_t));
+    local_yuv420_buffer = (uint8_t *) malloc(yuv420Size * sizeof(uint8_t) * 4);
 
     if (!local_yuv420_buffer)
     {
@@ -386,7 +386,7 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
 
     // Read yuv420 buffer from gpu
     ret |= clEnqueueReadBuffer(command_queue, yuv420_buffer, CL_TRUE, 0,
-        yuv420Size * sizeof(uint8_t), local_yuv420_buffer, 0, NULL, NULL);
+        yuv420Size * sizeof(uint8_t) * 4, local_yuv420_buffer, 0, NULL, NULL);
     if (ret)
     {
         std::cerr << "clEnqueueReadBuffer failed!" << std::endl;

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -1,0 +1,192 @@
+#include <iostream>
+
+#include "opencl.hpp"
+
+static char const *cl_source_str = "									\n\
+__kernel void rgbx_2_yuv (__global  unsigned int * sourceImage,						\n\
+                          __global unsigned int * destImage,						\n\
+                          unsigned int srcWidth,							\n\
+                          unsigned int srcHeight,							\n\
+                          short rgb0)									\n\
+{													\n\
+    int i,j;												\n\
+    unsigned int pixels[4];										\n\
+    unsigned int posSrc, RGB, Y = 0, UV = 0, ValueY, ValueU, ValueV;					\n\
+    unsigned char r, g, b;										\n\
+													\n\
+    unsigned int posX = get_global_id(0);								\n\
+    unsigned int posY = get_global_id(1);								\n\
+    unsigned int yuvStride = srcWidth >> 2;								\n\
+													\n\
+    if (posX >= yuvStride || posY >= srcHeight)								\n\
+    	return;												\n\
+													\n\
+    posSrc = (posY * srcWidth) + (posX * 4);								\n\
+													\n\
+    pixels[0] = sourceImage [posSrc + 0];								\n\
+    pixels[1] = sourceImage [posSrc + 1];								\n\
+    pixels[2] = sourceImage [posSrc + 2];								\n\
+    pixels[3] = sourceImage [posSrc + 3];								\n\
+													\n\
+    for (i = 0; i < 4; i++)										\n\
+    {													\n\
+        RGB = pixels[i];										\n\
+        if (rgb0)											\n\
+        {												\n\
+            r = (RGB) & 0xff; g = (RGB >> 8) & 0xff; b = (RGB >> 16) & 0xff;				\n\
+        }												\n\
+        else //bgr0											\n\
+        {												\n\
+            b = (RGB) & 0xff; g = (RGB >> 8) & 0xff; r = (RGB >> 16) & 0xff;				\n\
+        }												\n\
+													\n\
+        // Y plane - pack 4 * 8-bit Y's within each 32-bit unit.					\n\
+        // Each 24-bit RGB value is sampled and converted into an					\n\
+        // 8-bit Y value which represent the pixels as grayscale.					\n\
+        ValueY = ((66 * r + 129 * g + 25 * b) >> 8) + 16;						\n\
+        Y |= (ValueY << (i * 8));									\n\
+													\n\
+        // UV plane - pack 1 * 8-bit U and 1 * 8-bit V for each sampled pixel				\n\
+        // In this case the target is nv12/yuv420 which means we only sample				\n\
+        // every other row and every other pixel in each row						\n\
+        if (!(posY % 2) && !(i % 2))									\n\
+        {												\n\
+            ValueU = ((-38 * r + -74 * g + 112 * b) >> 8) + 128;					\n\
+            ValueV = ((112 * r - 94 * g - 18 * b) >> 8) + 128;						\n\
+            UV |= (ValueU << (i * 8));									\n\
+            UV |= (ValueV << ((i + 1) * 8));								\n\
+        }												\n\
+    }													\n\
+													\n\
+    destImage [(posY * yuvStride) + posX] = Y;								\n\
+    if (!(posY % 2))											\n\
+        destImage [(yuvStride * srcHeight) + ((posY >> 1) * yuvStride) + posX] = UV;			\n\
+    return;												\n\
+}													\n\
+";
+
+OpenCL::OpenCL(int _width, int _height)
+{
+    width = _width;
+    height = _height;
+
+    // Get platform and device information
+    cl_platform_id platform_id = NULL;
+    cl_device_id device_id = NULL;   
+    cl_uint ret_num_devices;
+    cl_uint ret_num_platforms;
+    cl_int ret = clGetPlatformIDs(1, &platform_id, &ret_num_platforms);
+    ret = clGetDeviceIDs( platform_id, CL_DEVICE_TYPE_DEFAULT, 1, 
+            &device_id, &ret_num_devices);
+
+    std::cout << "clGetDeviceIDs: " << ret_num_devices << std::endl;
+
+    // Create an OpenCL context
+    context = clCreateContext( NULL, 1, &device_id, NULL, NULL, &ret);
+    if (ret)
+        std::cerr << "clCreateContext failed!" << std::endl;
+
+    // Create a command queue
+    command_queue = clCreateCommandQueue(context, device_id, 0, &ret);
+    if (ret)
+        std::cerr << "clCreateCommandQueue failed!" << std::endl;
+    // Create a program from the kernel source
+    program = clCreateProgramWithSource(context, 1, 
+            (const char **)&cl_source_str, NULL, &ret);
+    if (ret)
+        std::cerr << "clCreateProgramWithSource failed!" << std::endl;
+
+    // Build the program
+    ret |= clBuildProgram(program, 1, &device_id, NULL, NULL, NULL);
+    if (ret)
+        std::cerr << "clBuildProgram failed!" << std::endl;
+
+    if (ret)
+    {
+        char *build_log;
+        size_t ret_val_size;
+        clGetProgramBuildInfo(program, device_id, CL_PROGRAM_BUILD_LOG, 0, NULL, &ret_val_size);
+        build_log = new char[ret_val_size+1];
+        clGetProgramBuildInfo(program, device_id, CL_PROGRAM_BUILD_LOG, ret_val_size, build_log, NULL);
+        std::cout << build_log << std::endl;
+        delete build_log;
+    }
+
+    // Create the OpenCL kernel
+    kernel = clCreateKernel(program, "rgbx_2_yuv", &ret);
+    if (ret)
+        std::cerr << "clCreateKernel failed!" << std::endl;
+
+    unsigned int frameSize = width * height;
+    argbSize = frameSize * 4; // ARGB pixels
+
+    yuvSize = frameSize + (frameSize >> 1); // Y+UV planes
+
+    yuvStride = width >> 2; // since we pack 4 RGBs into "one" YYYY
+
+    yuv_buffer = clCreateBuffer ( context, CL_MEM_WRITE_ONLY, yuvSize * sizeof(uint32_t), 0, &ret );
+    if (ret)
+        std::cerr << "clCreateBuffer (yuv) failure!" << std::endl;
+}
+
+int
+OpenCL::do_frame(const uint8_t* pixels, uint32_t **local_yuv_buffer, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert)
+{
+    cl_int ret = 0;
+    const uint8_t *formatted_pixels = pixels;
+    *local_yuv_buffer = (uint32_t*)malloc(yuvSize * sizeof(uint32_t));
+
+    rgb_buffer = clCreateBuffer ( context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, argbSize, (void *) pixels, &ret );
+    if (ret)
+        std::cerr << "clCreateBuffer (rgb) failed!" << std::endl;
+
+    short rgb0 = format == AV_PIX_FMT_RGB0 ? 1 : 0;
+    ret |= clSetKernelArg  ( kernel, 0, sizeof(cl_mem), &rgb_buffer );
+    ret |= clSetKernelArg ( kernel, 1, sizeof(cl_mem), &yuv_buffer );
+    ret |= clSetKernelArg ( kernel, 2, sizeof(unsigned int), &width);
+    ret |= clSetKernelArg ( kernel, 3, sizeof(unsigned int), &height);
+    ret |= clSetKernelArg ( kernel, 4, sizeof(short), &rgb0);
+    if (ret)
+        std::cerr << "clSetKernelArg failed!" << std::endl;
+
+    const size_t global_ws[] = { yuvStride + (yuvStride >> 1), size_t(height) };
+    ret |= clEnqueueNDRangeKernel ( command_queue, kernel, 2, NULL, global_ws, NULL, 0, NULL, NULL );
+    if (ret)
+        std::cerr << "clEnqueueNDRangeKernel failed!" << std::endl;
+
+    // Read yuv buffer from gpu
+    ret |= clEnqueueReadBuffer(command_queue, yuv_buffer, CL_TRUE, 0, 
+            yuvSize * sizeof(uint32_t), *local_yuv_buffer, 0, NULL, NULL);
+    if (ret)
+        std::cerr << "clEnqueueReadBuffer failed!" << std::endl;
+
+    formatted_pixels = *(uint8_t **) local_yuv_buffer;
+    if (y_invert)
+        formatted_pixels += width * (height - 1);
+
+    encoder_frame->data[0] = (uint8_t *) formatted_pixels;
+
+    if (y_invert)
+        formatted_pixels += width * height >> 1;
+    else
+        formatted_pixels += width * height;
+
+    encoder_frame->data[1] = (uint8_t *) formatted_pixels;
+
+    encoder_frame->linesize[0] = -width;
+    encoder_frame->linesize[1] = -width;
+
+    return ret;
+}
+
+OpenCL::~OpenCL()
+{
+    // Clean up OpenCL
+    clFlush(command_queue);
+    clFinish(command_queue);
+    clReleaseKernel(kernel);
+    clReleaseProgram(program);
+    clReleaseMemObject(yuv_buffer);
+    clReleaseCommandQueue(command_queue);
+    clReleaseContext(context);
+}

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -226,6 +226,8 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     encoder_frame->linesize[0] = -width;
     encoder_frame->linesize[1] = -width;
 
+    clReleaseMemObject(rgb_buffer);
+
     return ret;
 }
 
@@ -235,6 +237,7 @@ OpenCL::~OpenCL()
     clFinish(command_queue);
     clReleaseKernel(kernel);
     clReleaseProgram(program);
+    clReleaseMemObject(rgb_buffer);
     clReleaseMemObject(nv12_buffer);
     clReleaseCommandQueue(command_queue);
     clReleaseContext(context);

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -19,7 +19,7 @@ __kernel void rgbx_2_yuv (__global  unsigned int * sourceImage,						\n\
     unsigned int yuvStride = srcWidth >> 2;								\n\
 													\n\
     if (posX >= yuvStride || posY >= srcHeight)								\n\
-    	return;												\n\
+        return;												\n\
 													\n\
     posSrc = (posY * srcWidth) + (posX * 4);								\n\
 													\n\
@@ -72,37 +72,48 @@ OpenCL::OpenCL(int _width, int _height)
 
     // Get platform and device information
     cl_platform_id platform_id = NULL;
-    cl_device_id device_id = NULL;   
+    cl_device_id device_id = NULL;
     cl_uint ret_num_devices;
     cl_uint ret_num_platforms;
     cl_int ret = clGetPlatformIDs(1, &platform_id, &ret_num_platforms);
-    ret = clGetDeviceIDs( platform_id, CL_DEVICE_TYPE_DEFAULT, 1, 
-            &device_id, &ret_num_devices);
-
-    std::cout << "clGetDeviceIDs: " << ret_num_devices << std::endl;
+    ret = clGetDeviceIDs( platform_id, CL_DEVICE_TYPE_DEFAULT, 1,
+        &device_id, &ret_num_devices);
+    if (ret)
+    {
+        std::cerr << "clGetDeviceIDs failed!" << std::endl;
+        return;
+    }
 
     // Create an OpenCL context
     context = clCreateContext( NULL, 1, &device_id, NULL, NULL, &ret);
     if (ret)
+    {
         std::cerr << "clCreateContext failed!" << std::endl;
+        return;
+    }
 
     // Create a command queue
     command_queue = clCreateCommandQueue(context, device_id, 0, &ret);
     if (ret)
+    {
         std::cerr << "clCreateCommandQueue failed!" << std::endl;
+        return;
+    }
     // Create a program from the kernel source
-    program = clCreateProgramWithSource(context, 1, 
-            (const char **)&cl_source_str, NULL, &ret);
+    program = clCreateProgramWithSource(context, 1,
+        (const char **)&cl_source_str, NULL, &ret);
     if (ret)
+    {
         std::cerr << "clCreateProgramWithSource failed!" << std::endl;
+        return;
+    }
 
     // Build the program
     ret |= clBuildProgram(program, 1, &device_id, NULL, NULL, NULL);
     if (ret)
+    {
         std::cerr << "clBuildProgram failed!" << std::endl;
 
-    if (ret)
-    {
         char *build_log;
         size_t ret_val_size;
         clGetProgramBuildInfo(program, device_id, CL_PROGRAM_BUILD_LOG, 0, NULL, &ret_val_size);
@@ -115,7 +126,10 @@ OpenCL::OpenCL(int _width, int _height)
     // Create the OpenCL kernel
     kernel = clCreateKernel(program, "rgbx_2_yuv", &ret);
     if (ret)
+    {
         std::cerr << "clCreateKernel failed!" << std::endl;
+        return;
+    }
 
     unsigned int frameSize = width * height;
     argbSize = frameSize * 4; // ARGB pixels
@@ -126,41 +140,64 @@ OpenCL::OpenCL(int _width, int _height)
 
     yuv_buffer = clCreateBuffer ( context, CL_MEM_WRITE_ONLY, yuvSize * sizeof(uint32_t), 0, &ret );
     if (ret)
+    {
         std::cerr << "clCreateBuffer (yuv) failure!" << std::endl;
+        return;
+    }
+
+    local_yuv_buffer = (uint32_t *) malloc(yuvSize * sizeof(uint32_t));
+
+    if (!local_yuv_buffer)
+        std::cerr << "malloc failure!" << std::endl;
+
+    std::cout << "Using OpenCL for accelerated RGB to YUV conversion" << std::endl;
 }
 
 int
-OpenCL::do_frame(const uint8_t* pixels, uint32_t **local_yuv_buffer, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert)
+OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert)
 {
-    cl_int ret = 0;
     const uint8_t *formatted_pixels = pixels;
-    *local_yuv_buffer = (uint32_t*)malloc(yuvSize * sizeof(uint32_t));
+    short rgb0 = format == AV_PIX_FMT_RGB0 ? 1 : 0;
+
+    if (ret)
+        return ret;
 
     rgb_buffer = clCreateBuffer ( context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, argbSize, (void *) pixels, &ret );
     if (ret)
+    {
         std::cerr << "clCreateBuffer (rgb) failed!" << std::endl;
+        return -1;
+    }
 
-    short rgb0 = format == AV_PIX_FMT_RGB0 ? 1 : 0;
-    ret |= clSetKernelArg  ( kernel, 0, sizeof(cl_mem), &rgb_buffer );
+    ret |= clSetKernelArg ( kernel, 0, sizeof(cl_mem), &rgb_buffer );
     ret |= clSetKernelArg ( kernel, 1, sizeof(cl_mem), &yuv_buffer );
     ret |= clSetKernelArg ( kernel, 2, sizeof(unsigned int), &width);
     ret |= clSetKernelArg ( kernel, 3, sizeof(unsigned int), &height);
     ret |= clSetKernelArg ( kernel, 4, sizeof(short), &rgb0);
     if (ret)
+    {
         std::cerr << "clSetKernelArg failed!" << std::endl;
+        return -1;
+    }
 
     const size_t global_ws[] = { yuvStride + (yuvStride >> 1), size_t(height) };
     ret |= clEnqueueNDRangeKernel ( command_queue, kernel, 2, NULL, global_ws, NULL, 0, NULL, NULL );
     if (ret)
+    {
         std::cerr << "clEnqueueNDRangeKernel failed!" << std::endl;
+        return -1;
+    }
 
     // Read yuv buffer from gpu
-    ret |= clEnqueueReadBuffer(command_queue, yuv_buffer, CL_TRUE, 0, 
-            yuvSize * sizeof(uint32_t), *local_yuv_buffer, 0, NULL, NULL);
+    ret |= clEnqueueReadBuffer(command_queue, yuv_buffer, CL_TRUE, 0,
+        yuvSize * sizeof(uint32_t), local_yuv_buffer, 0, NULL, NULL);
     if (ret)
+    {
         std::cerr << "clEnqueueReadBuffer failed!" << std::endl;
+        return -1;
+    }
 
-    formatted_pixels = *(uint8_t **) local_yuv_buffer;
+    formatted_pixels = (uint8_t *) local_yuv_buffer;
     if (y_invert)
         formatted_pixels += width * (height - 1);
 
@@ -181,7 +218,6 @@ OpenCL::do_frame(const uint8_t* pixels, uint32_t **local_yuv_buffer, AVFrame *en
 
 OpenCL::~OpenCL()
 {
-    // Clean up OpenCL
     clFlush(command_queue);
     clFinish(command_queue);
     clReleaseKernel(kernel);
@@ -189,4 +225,5 @@ OpenCL::~OpenCL()
     clReleaseMemObject(yuv_buffer);
     clReleaseCommandQueue(command_queue);
     clReleaseContext(context);
+    free(local_yuv_buffer);
 }

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -40,7 +40,7 @@ __kernel void rgbx_2_yuv420 (__global unsigned int  *sourceImage,					\n\
 													\n\
     for (i = 0; i < 4; i++)										\n\
     {													\n\
-        if (i == 1 && (posX + 1) > halfWidth)								\n\
+        if (i == 1 && ((posX * 2) + 1) >= srcWidth)							\n\
             continue;											\n\
         if (i > 1 && ((posSrc[1] + ((i - 1) >> 1)) >= (srcWidth * srcHeight)))				\n\
             break;											\n\
@@ -71,21 +71,21 @@ __kernel void rgbx_2_yuv420 (__global unsigned int  *sourceImage,					\n\
     c2 = ((pixels[0] >> 8) & 0xff);									\n\
     c3 = ((pixels[0] >> 16) & 0xff);									\n\
     d = 0;												\n\
-    if (posX + 1 == halfWidth)										\n\
+    if (((posX * 2) + 1) < srcWidth)									\n\
     {													\n\
         c1 += (pixels[1] & 0xff);									\n\
         c2 += ((pixels[1] >> 8) & 0xff);								\n\
         c3 += ((pixels[1] >> 16) & 0xff);								\n\
         d++;												\n\
     }													\n\
-    if (posY + 1 == halfHeight)										\n\
+    if (((posY * 2) + 1) < srcHeight)									\n\
     {													\n\
         c1 += (pixels[2] & 0xff);									\n\
         c2 += ((pixels[2] >> 8) & 0xff);								\n\
         c3 += ((pixels[2] >> 16) & 0xff);								\n\
         d++;												\n\
     }													\n\
-    if (posX + 1 == halfWidth && posY + 1 == halfHeight)						\n\
+    if (((posX * 2) + 1) < srcWidth && ((posY * 2) + 1) < srcHeight)					\n\
     {													\n\
         c1 += (pixels[3] & 0xff);									\n\
         c2 += ((pixels[3] >> 8) & 0xff);								\n\

--- a/src/opencl.cpp
+++ b/src/opencl.cpp
@@ -89,7 +89,7 @@ OpenCL::OpenCL(int _width, int _height)
     cl_uint ret_num_devices;
     cl_uint ret_num_platforms;
     cl_int ret = clGetPlatformIDs(1, &platform_id, &ret_num_platforms);
-    ret = clGetDeviceIDs( platform_id, CL_DEVICE_TYPE_DEFAULT, 1,
+    ret = clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_DEFAULT, 1,
         &device_id, &ret_num_devices);
     if (ret)
     {
@@ -98,7 +98,7 @@ OpenCL::OpenCL(int _width, int _height)
     }
 
     // Create an OpenCL context
-    context = clCreateContext( NULL, 1, &device_id, NULL, NULL, &ret);
+    context = clCreateContext(NULL, 1, &device_id, NULL, NULL, &ret);
     if (ret)
     {
         std::cerr << "clCreateContext failed!" << std::endl;
@@ -151,7 +151,7 @@ OpenCL::OpenCL(int _width, int _height)
 
     nv12Stride = width >> 2; // since we pack 4 RGBs into "one" YYYY
 
-    nv12_buffer = clCreateBuffer ( context, CL_MEM_WRITE_ONLY, nv12Size * sizeof(uint32_t), 0, &ret );
+    nv12_buffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, nv12Size * sizeof(uint32_t), 0, &ret);
     if (ret)
     {
         std::cerr << "clCreateBuffer (nv12) failure!" << std::endl;
@@ -175,7 +175,7 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     if (ret)
         return ret;
 
-    rgb_buffer = clCreateBuffer ( context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, argbSize, (void *) pixels, &ret );
+    rgb_buffer = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, argbSize, (void *) pixels, &ret);
     if (ret)
     {
         std::cerr << "clCreateBuffer (rgb) failed!" << std::endl;
@@ -194,7 +194,7 @@ OpenCL::do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat fo
     }
 
     const size_t global_ws[] = { nv12Stride + (nv12Stride >> 1), size_t(height) };
-    ret |= clEnqueueNDRangeKernel ( command_queue, kernel, 2, NULL, global_ws, NULL, 0, NULL, NULL );
+    ret |= clEnqueueNDRangeKernel(command_queue, kernel, 2, NULL, global_ws, NULL, 0, NULL, NULL);
     if (ret)
     {
         std::cerr << "clEnqueueNDRangeKernel failed!" << std::endl;

--- a/src/opencl.hpp
+++ b/src/opencl.hpp
@@ -2,13 +2,14 @@
 
 #pragma once
 
-#define CL_TARGET_OPENCL_VERSION 120
+#define CL_TARGET_OPENCL_VERSION 110
 
 #include <CL/opencl.h>
 #include "frame-writer.hpp"
 
 class OpenCL
 {
+    cl_device_id device_id;
     cl_mem yuv420_buffer, rgb_buffer;
     unsigned int argbSize, yuv420Size, width, height, halfWidth, halfHeight;
     cl_kernel kernel;
@@ -17,14 +18,16 @@ class OpenCL
     cl_program program;
     cl_int ret = 0;
     uint8_t *local_yuv420_buffer;
+    cl_device_id get_device_id(int device);
 
     public:
 
-    OpenCL(int width, int height);
+    OpenCL(int device);
     ~OpenCL();
+
+    int
+    init(int width, int height);
 
     int
     do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert);
 };
-
-extern std::unique_ptr<OpenCL> opencl;

--- a/src/opencl.hpp
+++ b/src/opencl.hpp
@@ -2,21 +2,21 @@
 
 #pragma once
 
-#define CL_TARGET_OPENCL_VERSION 220
+#define CL_TARGET_OPENCL_VERSION 120
 
 #include <CL/opencl.h>
 #include "frame-writer.hpp"
 
 class OpenCL
 {
-    cl_mem nv12_buffer, rgb_buffer;
-    unsigned int argbSize, nv12Size, nv12Stride, width, height;
+    cl_mem yuv420_buffer, rgb_buffer;
+    unsigned int argbSize, yuv420Size, width, height, halfWidth, halfHeight;
     cl_kernel kernel;
     cl_context context;
     cl_command_queue command_queue;
     cl_program program;
     cl_int ret = 0;
-    uint32_t *local_nv12_buffer;
+    uint8_t *local_yuv420_buffer;
 
     public:
 

--- a/src/opencl.hpp
+++ b/src/opencl.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#define CL_TARGET_OPENCL_VERSION 220
+
+#include <CL/opencl.h>
+#include "frame-writer.hpp"
+
+class OpenCL
+{
+    cl_mem yuv_buffer, rgb_buffer;
+    unsigned int argbSize, yuvSize, yuvStride, width, height;
+    cl_kernel kernel;
+    cl_context context;
+    cl_command_queue command_queue;
+    cl_program program;
+
+    public:
+
+    OpenCL(int width, int height);
+    ~OpenCL();
+
+    int
+    do_frame(const uint8_t* pixels, uint32_t **local_yuv_buffer, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert);
+};
+
+extern std::unique_ptr<OpenCL> opencl;

--- a/src/opencl.hpp
+++ b/src/opencl.hpp
@@ -15,13 +15,14 @@ class OpenCL
     cl_context context;
     cl_command_queue command_queue;
     cl_program program;
-    cl_int ret = 0;
     uint32_t *local_nv12_buffer;
 
     public:
 
     OpenCL(int width, int height);
     ~OpenCL();
+
+    cl_int ret = 0;
 
     int
     do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert);

--- a/src/opencl.hpp
+++ b/src/opencl.hpp
@@ -15,14 +15,13 @@ class OpenCL
     cl_context context;
     cl_command_queue command_queue;
     cl_program program;
+    cl_int ret = 0;
     uint32_t *local_nv12_buffer;
 
     public:
 
     OpenCL(int width, int height);
     ~OpenCL();
-
-    cl_int ret = 0;
 
     int
     do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert);

--- a/src/opencl.hpp
+++ b/src/opencl.hpp
@@ -13,6 +13,8 @@ class OpenCL
     cl_context context;
     cl_command_queue command_queue;
     cl_program program;
+    cl_int ret = 0;
+    uint32_t *local_yuv_buffer;
 
     public:
 
@@ -20,7 +22,7 @@ class OpenCL
     ~OpenCL();
 
     int
-    do_frame(const uint8_t* pixels, uint32_t **local_yuv_buffer, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert);
+    do_frame(const uint8_t* pixels, AVFrame *encoder_frame, AVPixelFormat format, bool y_invert);
 };
 
 extern std::unique_ptr<OpenCL> opencl;

--- a/src/opencl.hpp
+++ b/src/opencl.hpp
@@ -1,3 +1,5 @@
+/* Copyright 2019 Scott Moreau */
+
 #pragma once
 
 #define CL_TARGET_OPENCL_VERSION 220

--- a/src/opencl.hpp
+++ b/src/opencl.hpp
@@ -9,14 +9,14 @@
 
 class OpenCL
 {
-    cl_mem yuv_buffer, rgb_buffer;
-    unsigned int argbSize, yuvSize, yuvStride, width, height;
+    cl_mem nv12_buffer, rgb_buffer;
+    unsigned int argbSize, nv12Size, nv12Stride, width, height;
     cl_kernel kernel;
     cl_context context;
     cl_command_queue command_queue;
     cl_program program;
     cl_int ret = 0;
-    uint32_t *local_yuv_buffer;
+    uint32_t *local_nv12_buffer;
 
     public:
 


### PR DESCRIPTION
This attempts to use OpenCL to convert rgb data to yuv instead of sws_scale() when wf-recorder is built with OpenCL support and the --to-yuv or -t option is passed. This helps offload work to the gpu that would otherwise be done on the cpu.