### PR TITLE
frame-writer: try to guess format for streaming

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -300,6 +300,16 @@ void FrameWriter::init_sws(AVPixelFormat format)
     }
 }
 
+static const char* determine_output_format(const std::string& output_name)
+{
+    if (output_name.find("rtmp") == 0)
+        return "flv";
+    if (output_name.find("udp") == 0)
+        return "mpegts";
+
+    return NULL;
+}
+
 FrameWriter::FrameWriter(const FrameWriterParams& _params) :
     params(_params)
 {
@@ -309,13 +319,10 @@ FrameWriter::FrameWriter(const FrameWriterParams& _params) :
     // Preparing the data concerning the format and codec,
     // in order to write properly the header, frame data and end of file.
     this->outputFmt = av_guess_format(NULL, params.file.c_str(), NULL);
-    if (!outputFmt)
-    {
-        std::cerr << "Failed to guess output format for file " << params.file << std::endl;
-        std::exit(-1);
-    }
-
-    if (avformat_alloc_output_context2(&this->fmtCtx, NULL, NULL, params.file.c_str()) < 0)
+    auto streamFormat = determine_output_format(params.file);
+    auto context_ret = avformat_alloc_output_context2(&this->fmtCtx, NULL,
+        streamFormat, params.file.c_str());
+    if (context_ret < 0)
     {
         std::cerr << "Failed to allocate output context" << std::endl;
         std::exit(-1);
@@ -568,7 +575,7 @@ FrameWriter::~FrameWriter()
     av_write_trailer(fmtCtx);
 
     // Closing the file.
-    if (!(outputFmt->flags & AVFMT_NOFILE))
+    if (outputFmt && (!(outputFmt->flags & AVFMT_NOFILE)))
         avio_closep(&fmtCtx->pb);
 
     avcodec_close(videoStream->codec);


### PR DESCRIPTION
Fix #40 

@disruptek Can you test this? You should be able to directly say the rtmp/udp address to stream to, no need for additional parameters.

EDIT: I have tested with twitch only, and it works fine.