### PR TITLE
Support writing to video loopback: Libavdevice and set muxer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ to select and limit the recording to a part of the screen.
 
 To specify a codec, use the `-c <codec>` option. To modify codec parameters, use `-p <option_name>=<option_value>`
 
+To set a specific output format use the `--muxer` option. For example, to output to a video4linux2 loopback you might use:
+```
+wf-recorder --muxer=v4l2 --codec=rawvideo --file=/dev/video2
+```
+
 To use gpu encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU device to use with the `-d` option:
 ```
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128

--- a/config.h.in
+++ b/config.h.in
@@ -1,3 +1,5 @@
 #pragma once
 
 #define DEFAULT_CODEC "@default_codec@"
+#mesondefine HAVE_LIBAVDEVICE
+

--- a/manpage/wf-recorder.1.scd
+++ b/manpage/wf-recorder.1.scd
@@ -37,6 +37,9 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 
 	You can check the muxers that your FFmpeg installation supports by running  : *ffmpeg -muxers*
 
+*-m, --muxer*
+	Set the output format to a specific muxer instead of detecting it from the filename.
+
 *-g, --geometry*            
 	Selects a specific part of the screen.
 

--- a/manpage/wf-recorder.1.scd
+++ b/manpage/wf-recorder.1.scd
@@ -40,6 +40,9 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 *-m, --muxer*
 	Set the output format to a specific muxer instead of detecting it from the filename.
 
+*-x, --pixel-format*
+	Set the output pixel format. These can be found by running : *ffmpeg -pix_fmts*
+
 *-g, --geometry*            
 	Selects a specific part of the screen.
 

--- a/meson.build
+++ b/meson.build
@@ -17,10 +17,6 @@ conf_data = configuration_data()
 
 conf_data.set('default_codec', get_option('default_codec'))
 
-configure_file(input: 'config.h.in',
-               output: 'config.h',
-               configuration: conf_data)
-
 include_directories(['.'])
 
 add_project_arguments(['-Wno-deprecated-declarations'], language: 'cpp')
@@ -31,6 +27,7 @@ wayland_protos = dependency('wayland-protocols')
 libavutil = dependency('libavutil')
 libavcodec = dependency('libavcodec')
 libavformat = dependency('libavformat')
+libavdevice = dependency('libavdevice', required: false)
 sws = dependency('libswscale')
 swr = dependency('libswresample')
 threads = dependency('threads')
@@ -63,7 +60,19 @@ if scdoc.found()
 	)
 endif
 
+conf_data.set('HAVE_LIBAVDEVICE', libavdevice.found())
+
+configure_file(input: 'config.h.in',
+               output: 'config.h',
+               configuration: conf_data)
+
 subdir('proto')
+
+dependencies = [wayland_client, wayland_protos, libavutil, libavcodec, libavformat, libavdevice, wf_protos, sws, threads, pulse, swr]
+if libavdevice.found()
+    dependencies += libavdevice
+endif
+
 executable('wf-recorder', ['src/frame-writer.cpp', 'src/main.cpp', 'src/pulse.cpp', 'src/averr.c'],
-        dependencies: [wayland_client, wayland_protos, libavutil, libavcodec, libavformat, wf_protos, sws, threads, pulse, swr],
+        dependencies: dependencies,
         install: true)

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -113,9 +113,14 @@ AVPixelFormat FrameWriter::get_input_format()
 
 AVPixelFormat FrameWriter::choose_sw_format(AVCodec *codec)
 {
-    /* First case: if the codec supports getting the appropriate RGB format
-     * directly, we want to use it since we don't have to convert data */
     auto in_fmt = get_input_format();
+
+    /* For codecs such as rawvideo no supported formats are listed */
+    if (!codec->pix_fmts)
+        return in_fmt;
+
+    /* If the codec supports getting the appropriate RGB format
+     * directly, we want to use it since we don't have to convert data */
     if (is_fmt_supported(in_fmt, codec->pix_fmts))
         return in_fmt;
 

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -324,6 +324,10 @@ FrameWriter::FrameWriter(const FrameWriterParams& _params) :
     if (params.enable_ffmpeg_debug_output)
         av_log_set_level(AV_LOG_DEBUG);
 
+#ifdef HAVE_LIBAVDEVICE
+    avdevice_register_all();
+#endif
+
     // Preparing the data concerning the format and codec,
     // in order to write properly the header, frame data and end of file.
     this->outputFmt = av_guess_format(NULL, params.file.c_str(), NULL);

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -304,11 +304,15 @@ void FrameWriter::init_sws(AVPixelFormat format)
     }
 }
 
-static const char* determine_output_format(const std::string& output_name)
+static const char* determine_output_format(const FrameWriterParams& params)
 {
-    if (output_name.find("rtmp") == 0)
+    if (!params.muxer.empty())
+        return params.muxer.c_str();
+
+    if (params.file.find("rtmp") == 0)
         return "flv";
-    if (output_name.find("udp") == 0)
+
+    if (params.file.find("udp") == 0)
         return "mpegts";
 
     return NULL;
@@ -323,7 +327,7 @@ FrameWriter::FrameWriter(const FrameWriterParams& _params) :
     // Preparing the data concerning the format and codec,
     // in order to write properly the header, frame data and end of file.
     this->outputFmt = av_guess_format(NULL, params.file.c_str(), NULL);
-    auto streamFormat = determine_output_format(params.file);
+    auto streamFormat = determine_output_format(params);
     auto context_ret = avformat_alloc_output_context2(&this->fmtCtx, NULL,
         streamFormat, params.file.c_str());
     if (context_ret < 0)

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -111,9 +111,23 @@ AVPixelFormat FrameWriter::get_input_format()
         AV_PIX_FMT_BGR0 : AV_PIX_FMT_RGB0;
 }
 
+AVPixelFormat FrameWriter::lookup_pixel_format(std::string pix_fmt)
+{
+    AVPixelFormat fmt = av_get_pix_fmt(pix_fmt.c_str());
+
+    if (fmt != AV_PIX_FMT_NONE)
+      return fmt;
+
+    std::cerr << "Failed to find the pixel format: " << pix_fmt << std::endl;
+    std::exit(-1);
+}
+
 AVPixelFormat FrameWriter::choose_sw_format(AVCodec *codec)
 {
     auto in_fmt = get_input_format();
+
+    if (!params.pix_fmt.empty())
+        return lookup_pixel_format(params.pix_fmt);
 
     /* For codecs such as rawvideo no supported formats are listed */
     if (!codec->pix_fmts)

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -38,6 +38,7 @@ struct FrameWriterParams
     InputFormat format;
 
     std::string codec;
+    std::string muxer;
     std::string hw_device; // used only if codec contains vaapi
     std::map<std::string, std::string> codec_options;
 

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -43,6 +43,7 @@ struct FrameWriterParams
 
     std::string codec;
     std::string muxer;
+    std::string pix_fmt;
     std::string hw_device; // used only if codec contains vaapi
     std::map<std::string, std::string> codec_options;
 
@@ -68,6 +69,7 @@ class FrameWriter
     AVBufferRef *hw_device_context = NULL;
     AVBufferRef *hw_frame_context = NULL;
 
+    AVPixelFormat lookup_pixel_format(std::string pix_fmt);
     AVPixelFormat choose_sw_format(AVCodec *codec);
     AVPixelFormat get_input_format();
     void init_hw_accel();

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include "config.h"
 
 #define AUDIO_RATE 44100
 
@@ -16,6 +17,9 @@ extern "C"
     #include <libswscale/swscale.h>
     #include <libswresample/swresample.h>
     #include <libavcodec/avcodec.h>
+#ifdef HAVE_LIBAVDEVICE
+    #include <libavdevice/avdevice.h>
+#endif
     #include <libavutil/mathematics.h>
     #include <libavformat/avformat.h>
     #include <libavutil/pixdesc.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -510,6 +510,9 @@ With no FILE, start recording the current screen.
                             You can check the muxers that your FFmpeg installation supports by
                             running  : ffmpeg -muxers
 
+  -m, --muxer               Set the output format to a specific muxer instead of detecting it
+                            from the filename.
+
   -g, --geometry            Selects a specific part of the screen.
 
   -h, --help                Prints this help screen.
@@ -567,6 +570,7 @@ int main(int argc, char *argv[])
     struct option opts[] = {
         { "output",          required_argument, NULL, 'o' },
         { "file",            required_argument, NULL, 'f' },
+        { "muxer",           required_argument, NULL, 'm' },
         { "geometry",        required_argument, NULL, 'g' },
         { "codec",           required_argument, NULL, 'c' },
         { "codec-param",     required_argument, NULL, 'p' },
@@ -591,6 +595,10 @@ int main(int argc, char *argv[])
 
             case 'o':
                 cmdline_output = optarg;
+                break;
+
+            case 'm':
+                params.muxer = optarg;
                 break;
 
             case 'g':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -513,6 +513,9 @@ With no FILE, start recording the current screen.
   -m, --muxer               Set the output format to a specific muxer instead of detecting it
                             from the filename.
 
+  -x, --pixel-format        Set the output pixel format. These can be found by running:
+                            *ffmpeg -pix_fmts*
+
   -g, --geometry            Selects a specific part of the screen.
 
   -h, --help                Prints this help screen.
@@ -571,6 +574,7 @@ int main(int argc, char *argv[])
         { "output",          required_argument, NULL, 'o' },
         { "file",            required_argument, NULL, 'f' },
         { "muxer",           required_argument, NULL, 'm' },
+        { "pixel-format",    required_argument, NULL, 'x' },
         { "geometry",        required_argument, NULL, 'g' },
         { "codec",           required_argument, NULL, 'c' },
         { "codec-param",     required_argument, NULL, 'p' },
@@ -599,6 +603,10 @@ int main(int argc, char *argv[])
 
             case 'm':
                 params.muxer = optarg;
+                break;
+
+            case 'x':
+                params.pix_fmt = optarg;
                 break;
 
             case 'g':


### PR DESCRIPTION
## What

- Add optional libavdevice support
- Adds `--muxer` option for setting output format when it can not be guessed from the filename
- Adds `--pixel-format` option needed to set `yuv420p` so video loopback output is compatible with zoom
- Fix segfault when `codec->pix_fmts` does not list any supported formats.

## Why

Allows wf-recorder to write out to various devices, and in particular the video4linux2 loopback. This can be picked up as a virtual webcam in screen-sharing applications like zoom, or can be displayed within a window with programs like `GUvcView`.

## Usage

1. Install `libavdevice-dev` and `v4l2loopback`. On my system the latter was packaged as `v4l2loobpack-utils` and `v4l2loopback-dkms`.
2. `modprobe v4l2loopback`
3. `v4l2-ctl --list-devices` to confirm the "Dummy video device" is present, and `v4l2-ctl --device=/dev/video2 --info` to get further info
4. `wf-recorder --muxer=v4l2 --codec=rawvideo --file=/dev/video2` to start screen output. For zoom add `pixel-format=yuv420p`.
5. Watch it! I installed GUvcView to help with this: `guvcview --device=/dev/video2 --gui=none`. You can also `ffplay /dev/video2`.