### PR TITLE
Make sure physical units, not logical units, are even

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -422,7 +422,7 @@ void FrameWriter::convert_pixels_to_yuv(const uint8_t *pixels,
 void FrameWriter::add_frame(const uint8_t* pixels, int64_t usec, bool y_invert)
 {
     /* Calculate data after y-inversion */
-    int stride[] = {int(4 * params.width)};
+    int stride[] = {int(params.stride)};
     const uint8_t *formatted_pixels = pixels;
     if (y_invert)
     {

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -46,6 +46,7 @@ struct FrameWriterParams
     std::string file;
     int width;
     int height;
+    int stride;
 
     InputFormat format;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,6 +184,12 @@ static void frame_handle_buffer(void *, struct zwlr_screencopy_frame_v1 *frame, 
     buffer.height = height;
     buffer.stride = stride;
 
+    /* ffmpeg requires even width and height */
+    if (buffer.width % 2)
+        buffer.width -= 1;
+    if (buffer.height % 2)
+        buffer.height -= 1;
+
     if (!buffer.wl_buffer) {
         buffer.wl_buffer =
             create_shm_buffer(format, width, height, stride, &buffer.data);
@@ -312,6 +318,7 @@ static void write_loop(FrameWriterParams params, PulseReaderParams pulseParams)
             params.format = get_input_format(buffer);
             params.width = buffer.width;
             params.height = buffer.height;
+            params.stride = buffer.stride;
             frame_writer = std::unique_ptr<FrameWriter> (new FrameWriter(params));
 
 #ifdef HAVE_OPENCL
@@ -430,22 +437,6 @@ struct capture_region
     capture_region(int32_t _x, int32_t _y, int32_t _width, int32_t _height)
         : x(_x), y(_y), width(_width), height(_height) { }
 
-    /* Make sure that dimension is even, while trying to keep the segment
-     * [coordinate, coordinate+dimension) as good as possible (i.e not going
-     * out of the monitor) */
-    void make_even(int32_t& coordinate, int32_t& dimension)
-    {
-        if (dimension % 2 == 0)
-            return;
-
-        /* We need to increase dimension to make it an even number */
-        ++dimension;
-
-        /* Try to decrease coordinate. If coordinate > 0, we can always lower it
-         * by 1 pixel and stay inside the screen. */
-        coordinate = std::max(coordinate - 1, 0);
-    }
-
     void set_from_string(std::string geometry_string)
     {
         if (sscanf(geometry_string.c_str(), "%d,%d %dx%d", &x, &y, &width, &height) != 4)
@@ -455,11 +446,6 @@ struct capture_region
             x = y = width = height = 0;
             return;
         }
-
-        /* ffmpeg requires even width and height */
-        make_even(x, width);
-        make_even(y, height);
-        printf("Adjusted geometry: %d,%d %dx%d\n", x, y, width, height);
     }
 
     bool is_selected()


### PR DESCRIPTION
The current wf-recorder just makes sure that the logical geometry provided by the user are even, but that doesn't guarantee that the dimensions of the buffer provided by zwlr_screencopy are even. With this patch, wf-recorder instead makes sure that the width and height of the physical buffer received from zwlr_screencopy is even.

This fixes https://github.com/ammen99/wf-recorder/issues/55.

There are a couple of behavior changes:

* The old code would potentially increase the width/height by one logical pixel. The new code potentially decreases the width/height by one physical pixel instead.
* The new code doesn't print `Adjusted geometry: %d,%d %dx%d`. If it's required, I could add it back, but I haven't because that would require adding global state to avoid printing the message for every new frame.