### PR TITLE
Quit wf-recorder when the recording target fails

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -601,7 +601,9 @@ void FrameWriter::finish_frame(AVCodecContext *enc_ctx, AVPacket& pkt)
         pending_mutex.unlock();
     }
 
-    av_interleaved_write_frame(fmtCtx, &pkt);
+    if (av_interleaved_write_frame(fmtCtx, &pkt) != 0) {
+        params.write_aborted_flag = true;
+    }
     av_packet_unref(&pkt);
 
     if (params.enable_audio)

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <atomic>
 #include "config.h"
 
 #define AUDIO_RATE 44100
@@ -64,6 +65,9 @@ struct FrameWriterParams
     bool force_yuv;
     int opencl_device;
     int bframes;
+
+    std::atomic<bool>& write_aborted_flag;
+    FrameWriterParams(std::atomic<bool>& flag): write_aborted_flag(flag) {}
 };
 
 class FrameWriter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -584,7 +584,7 @@ Examples:
 
 int main(int argc, char *argv[])
 {
-    FrameWriterParams params;
+    FrameWriterParams params = FrameWriterParams(exit_main_loop);
     params.file = "recording.mp4";
     params.codec = DEFAULT_CODEC;
     params.enable_ffmpeg_debug_output = false;


### PR DESCRIPTION
This can happen when the sdl muxer is used and the window is closed or when the target file reaches the filesystem limits.

    ./wf-recorder -c rawvideo -m sdl  -f pipe:mirror

I am not sure if this is the best solution, but it was the quickest fix.