### PR TITLE
Add support for changing audio codec options and video framerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ wf-recorder --audio --file=recording_with_audio.mp4
 
 To specify a video codec, use the `-c <codec>` option. To modify codec parameters, use `-p <option_name>=<option_value>`.
 
-You can also specify an audio codec, using `-u <codec>`. Alternatively, the long form `--acodec` also works. 
+You can also specify an audio codec, using `-C <codec>`. Alternatively, the long form `--acodec` can be used. 
 
 To set a specific output format, use the `--muxer` option. For example, to output to a video4linux2 loopback you might use:
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ You can record screen and sound simultaneously with
 wf-recorder --audio --file=recording_with_audio.mp4
 ```
 
-To specify a codec, use the `-c <codec>` option. To modify codec parameters, use `-p <option_name>=<option_value>`.
+To specify a video codec, use the `-c <codec>` option. To modify codec parameters, use `-p <option_name>=<option_value>`.
+
+You can also specify an audio codec, using `-u <codec>`. Alternatively, the long form `--acodec` also works. 
 
 To set a specific output format, use the `--muxer` option. For example, to output to a video4linux2 loopback you might use:
 ```

--- a/config.h.in
+++ b/config.h.in
@@ -4,7 +4,7 @@
 #define DEFAULT_FRAMERATE @default_framerate@
 #define DEFAULT_ACODEC "@default_acodec@"
 #define DEFAULT_SAMPLE_RATE @default_sample_rate@
-#define DEFAULT_SAMPLE_FMT "@default_sample_fmt@"
+#define FALLBACK_SAMPLE_FMT "@fallback_sample_fmt@"
 #mesondefine HAVE_PULSE
 #mesondefine HAVE_OPENCL
 #mesondefine HAVE_LIBAVDEVICE

--- a/config.h.in
+++ b/config.h.in
@@ -6,7 +6,7 @@
 #define DEFAULT_ACODEC "@default_acodec@"
 //#define DEFAULT_SAMPLE_RATE @default_sample_rate@
 #define DEFAULT_SAMPLE_RATE 44100
-#define DEFAULT_SAMPLE_FMT "@default_sample_fmt@"
+//#define DEFAULT_SAMPLE_FMT "@default_sample_fmt@"
 #mesondefine HAVE_PULSE
 #mesondefine HAVE_OPENCL
 #mesondefine HAVE_LIBAVDEVICE

--- a/config.h.in
+++ b/config.h.in
@@ -1,12 +1,10 @@
 #pragma once
 
 #define DEFAULT_CODEC "@default_codec@"
-//#define DEFAULT_FRAMERATE @default_framerate@
-#define DEFAULT_FRAMERATE 60
+#define DEFAULT_FRAMERATE @default_framerate@
 #define DEFAULT_ACODEC "@default_acodec@"
-//#define DEFAULT_SAMPLE_RATE @default_sample_rate@
-#define DEFAULT_SAMPLE_RATE 44100
-//#define DEFAULT_SAMPLE_FMT "@default_sample_fmt@"
+#define DEFAULT_SAMPLE_RATE @default_sample_rate@
+#define DEFAULT_SAMPLE_FMT "@default_sample_fmt@"
 #mesondefine HAVE_PULSE
 #mesondefine HAVE_OPENCL
 #mesondefine HAVE_LIBAVDEVICE

--- a/config.h.in
+++ b/config.h.in
@@ -1,7 +1,12 @@
 #pragma once
 
 #define DEFAULT_CODEC "@default_codec@"
+//#define DEFAULT_FRAMERATE @default_framerate@
+#define DEFAULT_FRAMERATE 60
 #define DEFAULT_ACODEC "@default_acodec@"
+//#define DEFAULT_SAMPLE_RATE @default_sample_rate@
+#define DEFAULT_SAMPLE_RATE 44100
+#define DEFAULT_SAMPLE_FMT "@default_sample_fmt@"
 #mesondefine HAVE_PULSE
 #mesondefine HAVE_OPENCL
 #mesondefine HAVE_LIBAVDEVICE

--- a/config.h.in
+++ b/config.h.in
@@ -1,6 +1,7 @@
 #pragma once
 
 #define DEFAULT_CODEC "@default_codec@"
+#define DEFAULT_ACODEC "@default_acodec@"
 #mesondefine HAVE_PULSE
 #mesondefine HAVE_OPENCL
 #mesondefine HAVE_LIBAVDEVICE

--- a/manpage/wf-recorder.1.scd
+++ b/manpage/wf-recorder.1.scd
@@ -20,7 +20,30 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 *-c, --codec*
 	Specifies the codec of the video. Supports GIF output as well.
 
-	To modify codec parameters, use *-p <option_name>=<option_value>*
+*-r, --framerate*
+	Changes an approximation of the video framerate. The default value is *60*.
+
+*-x, --pixel-format*
+	Set the output pixel format. List available formats using *ffmpeg -pix_fmts*
+
+*-p, --codec-param*
+	Change the video codec parameters.
+	
+	*-p <option_name>=<option_value>*
+
+*-C, --acodec*
+	Specifies the codec of the audio.
+
+*-R, --sample-rate*
+	Changes the audio sample rate, in HZ. The default value is *44100*.
+
+*-X, --sample-format*
+	Set the output audio sample format. List available formats using *ffmpeg -sample_fmts*
+
+*-P, --acodec-param*
+	Change the audio codec parameters.
+	
+	*-P <option_name>=<option_value>*
 
 *-d, --device*
 	Selects the device to use when encoding the video.
@@ -39,9 +62,6 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 
 *-m, --muxer*
 	Set the output format to a specific muxer instead of detecting it from the filename.
-
-*-x, --pixel-format*
-	Set the output pixel format. List available formats using *ffmpeg -pix_fmts*
 
 *-g, --geometry*
 	Selects a specific part of the screen.

--- a/manpage/wf-recorder.1.scd
+++ b/manpage/wf-recorder.1.scd
@@ -21,7 +21,7 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 	Specifies the codec of the video. Supports GIF output as well.
 
 *-r, --framerate*
-	Changes an approximation of the video framerate. The default value is *60*.
+	Changes an approximation of the video framerate.
 
 *-x, --pixel-format*
 	Set the output pixel format. List available formats using *ffmpeg -pix_fmts*
@@ -35,7 +35,7 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 	Specifies the codec of the audio.
 
 *-R, --sample-rate*
-	Changes the audio sample rate, in HZ. The default value is *44100*.
+	Changes the audio sample rate, in HZ.
 
 *-X, --sample-format*
 	Set the output audio sample format. List available formats using *ffmpeg -sample_fmts*

--- a/manpage/wf-recorder.1.scd
+++ b/manpage/wf-recorder.1.scd
@@ -24,7 +24,7 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 	Changes an approximation of the video framerate.
 
 *-x, --pixel-format*
-	Set the output pixel format. List available formats using *ffmpeg -pix_fmts*
+	Set the output video pixel format. List available formats using *ffmpeg -pix_fmts*
 
 *-p, --codec-param*
 	Change the video codec parameters.

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ project(
 conf_data = configuration_data()
 
 conf_data.set('default_codec', get_option('default_codec'))
+conf_data.set('default_acodec', get_option('default_acodec'))
 
 include_directories(['.'])
 

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ conf_data.set('default_codec', get_option('default_codec'))
 conf_data.set('default_framerate', get_option('default_framerate'))
 conf_data.set('default_acodec', get_option('default_acodec'))
 conf_data.set('default_sample_rate', get_option('default_sample_rate'))
-conf_data.set('default_sample_fmt', get_option('default_sample_fmt'))
+conf_data.set('fallback_sample_fmt', get_option('fallback_sample_fmt'))
 
 include_directories(['.'])
 

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,10 @@ project(
 conf_data = configuration_data()
 
 conf_data.set('default_codec', get_option('default_codec'))
+conf_data.set('default_framerate', get_option('default_framerate'))
 conf_data.set('default_acodec', get_option('default_acodec'))
+conf_data.set('default_sample_rate', get_option('default_sample_rate'))
+conf_data.set('default_sample_fmt', get_option('default_sample_fmt'))
 
 include_directories(['.'])
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,7 @@ option('default_codec', type: 'string', value: 'libx264', description: 'Codec th
 option('default_framerate', type: 'integer', value: 60, description: 'Video framerate that will be used by default')
 option('default_acodec', type: 'string', value: 'aac', description: 'Audio codec that will be used by default')
 option('default_sample_rate', type: 'integer', value: 44100, description: 'Audio sample rate that will be used by default')
-option('default_sample_fmt', type: 'string', value: 's16', description: 'Audio sample format that will be used by default')
+option('fallback_sample_fmt', type: 'string', value: 's16', description: 'Fallback audio sample format that will be used if wf-recorder cannot determine the sample formats supported by a codec')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('pulse', type: 'feature', value: 'auto', description: 'Enable Pulseaudio')
 option('opencl', type: 'feature', value: 'auto', description: 'Enable OpenCL')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('default_codec', type: 'string', value: 'libx264', description: 'Codec that will be used by default')
+option('default_acodec', type: 'string', value: 'aac', description: 'Audio codec that will be used by default')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('pulse', type: 'feature', value: 'auto', description: 'Enable Pulseaudio')
 option('opencl', type: 'feature', value: 'auto', description: 'Enable OpenCL')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,8 @@
 option('default_codec', type: 'string', value: 'libx264', description: 'Codec that will be used by default')
+option('default_framerate', type: 'integer', value: 60, description: 'Video framerate that will be used by default')
 option('default_acodec', type: 'string', value: 'aac', description: 'Audio codec that will be used by default')
+option('default_sample_rate', type: 'integer', value: 44100, description: 'Audio sample rate that will be used by default')
+option('default_sample_fmt', type: 'string', value: 's16', description: 'Audio sample format that will be used by default')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('pulse', type: 'feature', value: 'auto', description: 'Enable Pulseaudio')
 option('opencl', type: 'feature', value: 'auto', description: 'Enable OpenCL')

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -260,7 +260,7 @@ static enum AVSampleFormat convert_codec_sample_fmt(AVCodec *codec, std::string 
 	std::exit(-1);
     } else if (!codec->sample_fmts || check_fmt_available(codec, converted_fmt))
     {
-        std::cout << "Using sample format " << av_get_sample_fmt_name(converted_fmt) << std::endl;
+        std::cout << "Using sample format " << av_get_sample_fmt_name(converted_fmt) << " for audio codec " << codec->name << std::endl;
         return converted_fmt;
     } else
     {

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -235,10 +235,10 @@ static enum AVSampleFormat get_codec_sample_fmt(AVCodec *codec)
 
 void FrameWriter::init_audio_stream()
 {
-    AVCodec* codec = avcodec_find_encoder_by_name("aac");
+    AVCodec* codec = avcodec_find_encoder_by_name(params.acodec.c_str());
     if (!codec)
     {
-        std::cerr << "Failed to find the aac codec" << std::endl;
+        std::cerr << "Failed to find the given audio codec: " << params.acodec << std::endl;
         std::exit(-1);
     }
 
@@ -250,7 +250,9 @@ void FrameWriter::init_audio_stream()
     }
 
     audioCodecCtx = audioStream->codec;
-    audioCodecCtx->bit_rate = lrintf(128000.0f);
+    if (params.codec.c_str() == "aac"){
+        audioCodecCtx->bit_rate = lrintf(128000.0f);
+    }
     audioCodecCtx->sample_fmt = get_codec_sample_fmt(codec);
     audioCodecCtx->channel_layout = get_codec_channel_layout(codec);
     audioCodecCtx->sample_rate = AUDIO_RATE;

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -258,7 +258,7 @@ static enum AVSampleFormat convert_codec_sample_fmt(AVCodec *codec, std::string 
     {
 	std::cout << "Failed to find the given sample format: " << requested_fmt << std::endl;
 	std::exit(-1);
-    } else if (check_fmt_available(codec, converted_fmt))
+    } else if (!codec->sample_fmts || check_fmt_available(codec, converted_fmt))
     {
         std::cout << "Using sample format " << av_get_sample_fmt_name(converted_fmt) << std::endl;
         return converted_fmt;

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -10,9 +10,6 @@
 #include <cstring>
 #include "averr.h"
 
-//#define FPS 60
-//#define AUDIO_RATE 44100
-
 class FFmpegInitialize
 {
 public :
@@ -246,10 +243,10 @@ static enum AVSampleFormat get_codec_auto_sample_fmt(AVCodec *codec)
 bool check_fmt_available(AVCodec *codec, AVSampleFormat fmt){
     for (const enum AVSampleFormat *sample_ptr = codec -> sample_fmts; *sample_ptr != -1; sample_ptr++)
     {
-	if (*sample_ptr == fmt)
-	{
-	    return true;
-	}
+        if (*sample_ptr == fmt)
+        {
+            return true;
+        }
     }
     return false;
 }

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -294,6 +294,7 @@ void FrameWriter::init_audio_stream()
     }
     if (params.sample_fmt.size() == 0){
 	audioCodecCtx->sample_fmt = get_codec_auto_sample_fmt(codec);
+	std::cout << "Choosing sample format " << av_get_sample_fmt_name(audioCodecCtx->sample_fmt) << " for audio codec " << codec->name << std::endl;
     } else
     {
 	audioCodecCtx->sample_fmt = convert_codec_sample_fmt(codec, params.sample_fmt);

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -229,7 +229,7 @@ static enum AVSampleFormat get_codec_auto_sample_fmt(AVCodec *codec)
 {
     int i = 0;
     if (!codec->sample_fmts)
-        return av_get_sample_fmt(DEFAULT_SAMPLE_FMT);
+        return av_get_sample_fmt(FALLBACK_SAMPLE_FMT);
     while (1) {
         if (codec->sample_fmts[i] == -1)
             break;

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -244,8 +244,10 @@ static enum AVSampleFormat get_codec_auto_sample_fmt(AVCodec *codec)
 }
 
 bool check_fmt_available(AVCodec *codec, AVSampleFormat fmt){
-    for (const enum AVSampleFormat *sample_ptr = codec -> sample_fmts; *sample_ptr != -1; sample_ptr++){
-	if (*sample_ptr == fmt){
+    for (const enum AVSampleFormat *sample_ptr = codec -> sample_fmts; *sample_ptr != -1; sample_ptr++)
+    {
+	if (*sample_ptr == fmt)
+	{
 	    return true;
 	}
     }
@@ -254,13 +256,17 @@ bool check_fmt_available(AVCodec *codec, AVSampleFormat fmt){
 
 static enum AVSampleFormat get_codec_sample_fmt(AVCodec *codec, AVSampleFormat requested_fmt)
 {
-    if (check_fmt_available(codec, requested_fmt))
+    if (requested_fmt == AV_SAMPLE_FMT_NONE)
     {
-        std::cout << "Using requested sample format: " << av_get_sample_fmt_name(requested_fmt) << std::endl;
+	std::cout << "Invalid sample format entered! Automatically determining sample format instead." << std::endl;
+	return get_codec_auto_sample_fmt(codec);
+    } else if (check_fmt_available(codec, requested_fmt))
+    {
+        std::cout << "Using requested sample format " << av_get_sample_fmt_name(requested_fmt) << std::endl;
         return requested_fmt;
     } else
     {
-	std::cout << "Couldn't use requested sample format: " << av_get_sample_fmt_name(requested_fmt) << "! Automatically picking an alternative." << std::endl;
+	std::cout << "Couldn't use requested sample format " << av_get_sample_fmt_name(requested_fmt) << "! Automatically picking an alternative." << std::endl;
         return get_codec_auto_sample_fmt(codec);
     }
 }

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -229,7 +229,7 @@ static enum AVSampleFormat get_codec_auto_sample_fmt(AVCodec *codec)
 {
     int i = 0;
     if (!codec->sample_fmts)
-        return AV_SAMPLE_FMT_S16;
+        return av_get_sample_fmt(DEFAULT_SAMPLE_FMT);
     while (1) {
         if (codec->sample_fmts[i] == -1)
             break;

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -52,6 +52,7 @@ struct FrameWriterParams
     InputFormat format;
 
     std::string codec;
+    std::string acodec;
     std::string muxer;
     std::string pix_fmt;
     std::string hw_device; // used only if codec contains vaapi

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -11,7 +11,7 @@
 #include <atomic>
 #include "config.h"
 
-#define AUDIO_RATE 44100
+//#define AUDIO_RATE 44100
 
 extern "C"
 {
@@ -55,8 +55,12 @@ struct FrameWriterParams
     std::string acodec;
     std::string muxer;
     std::string pix_fmt;
+    std::string sample_fmt;
     std::string hw_device; // used only if codec contains vaapi
     std::map<std::string, std::string> codec_options;
+    std::map<std::string, std::string> acodec_options;
+    int framerate;
+    int sample_rate;
 
     int64_t audio_sync_offset;
 
@@ -76,6 +80,7 @@ class FrameWriter
 {
     FrameWriterParams params;
     void load_codec_options(AVDictionary **dict);
+    void load_acodec_options(AVDictionary **dict);
 
     SwsContext* swsCtx;
     AVOutputFormat* outputFmt;

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -11,8 +11,6 @@
 #include <atomic>
 #include "config.h"
 
-//#define AUDIO_RATE 44100
-
 extern "C"
 {
     #include <libswscale/swscale.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -515,7 +515,7 @@ With no FILE, start recording the current screen.)");
 
   -c, --codec               Specifies the codec of the video. Supports  GIF output also.
 
-  -r, --framerate           Changes an approximation of the video framerate. The default is 60. 
+  -r, --framerate           Changes an approximation of the video framerate.
 
   -x, --pixel-format        Set the output pixel format. These can be found by running:
                             *ffmpeg -pix_fmts*
@@ -525,7 +525,7 @@ With no FILE, start recording the current screen.)");
 
   -C, --acodec              Specifies the codec of the audio. 
 
-  -R, --sample-rate         Changes the audio sample rate, in HZ. The default value is 44100. 
+  -R, --sample-rate         Changes the audio sample rate, in HZ.
 
   -X, --sample-format       Set the output audio sample format. These can be found by running: 
                             *ffmpeg -sample_fmts*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -556,35 +556,30 @@ With no FILE, start recording the current screen.)");
   -o, --output              Specify the output where the video is to be recorded.");
 #ifdef HAVE_OPENCL
     printf(R"(
-
   -e, --opencl              Use the -e[#] or --opencl[=#] in conjunction with -t or --force-yuv option
                             to use opencl for gpu accelerated conversion of data to yuv. # is one
                             of the devices listed when running without specifying #.)");
 #endif
     printf(R"(
-
   -t, --force-yuv           Use the -t or --force-yuv option to force conversion of the data to
                             yuv format, before sending it to the gpu.
-
   -b, --bframes             This option is used to set the maximum number of b-frames to be used.
                             If b-frames are not supported by your hardware, set this to 0.)" "\n\n" R"(
 Examples:)");
 #ifdef HAVE_PULSE
     printf(R"(
-
   Video Only:)");
 #endif
     printf(R"(
-
   - wf-recorder                         Records the video. Use Ctrl+C to stop recording.
                                         The video file will be stored as recording.mp4 in the
                                         current working directory.
-
   - wf-recorder -f <filename>.ext       Records the video. Use Ctrl+C to stop recording.
                                         The video file will be stored as <outputname>.ext in the
                                         current working directory.)");
 #ifdef HAVE_PULSE
     printf(R"(
+
 
   Video and Audio:
 
@@ -610,7 +605,7 @@ int main(int argc, char *argv[])
     params.framerate = DEFAULT_FRAMERATE;
     params.acodec = DEFAULT_ACODEC;
     params.sample_rate = DEFAULT_SAMPLE_RATE;
-    params.sample_fmt = DEFAULT_SAMPLE_FMT;
+    //params.sample_fmt = DEFAULT_SAMPLE_FMT;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
     params.force_yuv = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -515,6 +515,8 @@ With no FILE, start recording the current screen.)");
   -c, --codec               Specifies the codec of the video. Supports  GIF output also.
                             To modify codec parameters, use -p <option_name>=<option_value>
 
+  -u, --acodec              Specifies the codec of the audio. 
+
   -d, --device              Selects the device to use when encoding the video
                             Some drivers report support for rgb0 data for vaapi input but
                             really only support yuv.
@@ -595,6 +597,7 @@ int main(int argc, char *argv[])
     FrameWriterParams params = FrameWriterParams(exit_main_loop);
     params.file = "recording.mp4";
     params.codec = DEFAULT_CODEC;
+    params.acodec = DEFAULT_ACODEC;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
     params.force_yuv = false;
@@ -615,6 +618,7 @@ int main(int argc, char *argv[])
         { "geometry",        required_argument, NULL, 'g' },
         { "codec",           required_argument, NULL, 'c' },
         { "codec-param",     required_argument, NULL, 'p' },
+	{ "acodec",          required_argument, NULL, 'u' },
         { "device",          required_argument, NULL, 'd' },
         { "log",             no_argument,       NULL, 'l' },
         { "audio",           optional_argument, NULL, 'a' },
@@ -628,7 +632,7 @@ int main(int argc, char *argv[])
     int c, i;
     std::string param;
     size_t pos;
-    while((c = getopt_long(argc, argv, "o:f:m:x:g:c:p:d:b:la::te::h", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:m:x:g:c:p:u:d:b:la::te::h", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -655,6 +659,10 @@ int main(int argc, char *argv[])
             case 'c':
                 params.codec = optarg;
                 break;
+
+	    case 'u':
+	        params.acodec = optarg;
+	        break;
 
             case 'd':
                 params.hw_device = optarg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -345,6 +345,7 @@ static void write_loop(FrameWriterParams params)
             if (params.enable_audio)
             {
                 pulseParams.audio_frame_size = frame_writer->get_audio_buffer_size();
+		pulseParams.sample_rate = params.sample_rate;
                 pr = std::unique_ptr<PulseReader> (new PulseReader(pulseParams));
                 pr->start();
             }
@@ -534,6 +535,9 @@ With no FILE, start recording the current screen.)");
   -x, --pixel-format        Set the output pixel format. These can be found by running:
                             *ffmpeg -pix_fmts*
 
+  -X, --sample-format       Set the audio sample format. These can be found by running: 
+                            *ffmpeg -sample_fmts*
+
   -g, --geometry            Selects a specific part of the screen.
 
   -h, --help                Prints this help screen.
@@ -597,7 +601,10 @@ int main(int argc, char *argv[])
     FrameWriterParams params = FrameWriterParams(exit_main_loop);
     params.file = "recording.mp4";
     params.codec = DEFAULT_CODEC;
+    params.framerate = DEFAULT_FRAMERATE;
     params.acodec = DEFAULT_ACODEC;
+    params.sample_rate = DEFAULT_SAMPLE_RATE;
+    params.sample_fmt = DEFAULT_SAMPLE_FMT;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
     params.force_yuv = false;
@@ -614,11 +621,15 @@ int main(int argc, char *argv[])
         { "output",          required_argument, NULL, 'o' },
         { "file",            required_argument, NULL, 'f' },
         { "muxer",           required_argument, NULL, 'm' },
-        { "pixel-format",    required_argument, NULL, 'x' },
         { "geometry",        required_argument, NULL, 'g' },
         { "codec",           required_argument, NULL, 'c' },
         { "codec-param",     required_argument, NULL, 'p' },
+	{ "framerate",       required_argument, NULL, 'r' },
+        { "pixel-format",    required_argument, NULL, 'x' },
 	{ "acodec",          required_argument, NULL, 'C' },
+	{ "acodec-param",    required_argument, NULL, 'P' },
+	{ "sample-rate",     required_argument, NULL, 'R' },
+	{ "sample-format",   required_argument, NULL, 'X' },
         { "device",          required_argument, NULL, 'd' },
         { "log",             no_argument,       NULL, 'l' },
         { "audio",           optional_argument, NULL, 'a' },
@@ -632,7 +643,7 @@ int main(int argc, char *argv[])
     int c, i;
     std::string param;
     size_t pos;
-    while((c = getopt_long(argc, argv, "o:f:m:x:g:c:p:C:d:b:la::te::h", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:m:g:c:p:r:x:C:P:R:X:d:b:la::te::h", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -648,10 +659,6 @@ int main(int argc, char *argv[])
                 params.muxer = optarg;
                 break;
 
-            case 'x':
-                params.pix_fmt = optarg;
-                break;
-
             case 'g':
                 selected_region.set_from_string(optarg);
                 break;
@@ -660,9 +667,25 @@ int main(int argc, char *argv[])
                 params.codec = optarg;
                 break;
 
+	    case 'r':
+	        params.framerate = atoi(optarg);
+	 	break;
+
+            case 'x':
+                params.pix_fmt = optarg;
+                break;
+
 	    case 'C':
 	        params.acodec = optarg;
 	        break;
+
+	    case 'R':
+	        params.sample_rate = atoi(optarg);
+		break;
+
+	    case 'X':
+	        params.sample_fmt = optarg;
+		break;
 
             case 'd':
                 params.hw_device = optarg;
@@ -707,6 +730,20 @@ int main(int argc, char *argv[])
                     auto optname = param.substr(0, pos);
                     auto optvalue = param.substr(pos + 1, param.length() - pos - 1);
                     params.codec_options[optname] = optvalue;
+                } else
+                {
+                    printf("Invalid codec option %s\n", optarg);
+                }
+                break;
+
+	    case 'P':
+                param = optarg;
+                pos = param.find("=");
+                if (pos != std::string::npos && pos != param.length() - 1)
+                {
+                    auto optname = param.substr(0, pos);
+                    auto optvalue = param.substr(pos + 1, param.length() - pos - 1);
+                    params.acodec_options[optname] = optvalue;
                 } else
                 {
                     printf("Invalid codec option %s\n", optarg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -515,7 +515,7 @@ With no FILE, start recording the current screen.)");
   -c, --codec               Specifies the codec of the video. Supports  GIF output also.
                             To modify codec parameters, use -p <option_name>=<option_value>
 
-  -u, --acodec              Specifies the codec of the audio. 
+  -C, --acodec              Specifies the codec of the audio. 
 
   -d, --device              Selects the device to use when encoding the video
                             Some drivers report support for rgb0 data for vaapi input but
@@ -618,7 +618,7 @@ int main(int argc, char *argv[])
         { "geometry",        required_argument, NULL, 'g' },
         { "codec",           required_argument, NULL, 'c' },
         { "codec-param",     required_argument, NULL, 'p' },
-	{ "acodec",          required_argument, NULL, 'u' },
+	{ "acodec",          required_argument, NULL, 'C' },
         { "device",          required_argument, NULL, 'd' },
         { "log",             no_argument,       NULL, 'l' },
         { "audio",           optional_argument, NULL, 'a' },
@@ -632,7 +632,7 @@ int main(int argc, char *argv[])
     int c, i;
     std::string param;
     size_t pos;
-    while((c = getopt_long(argc, argv, "o:f:m:x:g:c:p:u:d:b:la::te::h", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:m:x:g:c:p:C:d:b:la::te::h", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -660,7 +660,7 @@ int main(int argc, char *argv[])
                 params.codec = optarg;
                 break;
 
-	    case 'u':
+	    case 'C':
 	        params.acodec = optarg;
 	        break;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -557,13 +557,11 @@ With no FILE, start recording the current screen.)");
 #ifdef HAVE_OPENCL
     printf(R"(
 
-
   -e, --opencl              Use the -e[#] or --opencl[=#] in conjunction with -t or --force-yuv option
                             to use opencl for gpu accelerated conversion of data to yuv. # is one
                             of the devices listed when running without specifying #.)");
 #endif
     printf(R"(
-
 
   -t, --force-yuv           Use the -t or --force-yuv option to force conversion of the data to
                             yuv format, before sending it to the gpu.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -556,30 +556,37 @@ With no FILE, start recording the current screen.)");
   -o, --output              Specify the output where the video is to be recorded.");
 #ifdef HAVE_OPENCL
     printf(R"(
+
+
   -e, --opencl              Use the -e[#] or --opencl[=#] in conjunction with -t or --force-yuv option
                             to use opencl for gpu accelerated conversion of data to yuv. # is one
                             of the devices listed when running without specifying #.)");
 #endif
     printf(R"(
+
+
   -t, --force-yuv           Use the -t or --force-yuv option to force conversion of the data to
                             yuv format, before sending it to the gpu.
+
   -b, --bframes             This option is used to set the maximum number of b-frames to be used.
                             If b-frames are not supported by your hardware, set this to 0.)" "\n\n" R"(
 Examples:)");
 #ifdef HAVE_PULSE
     printf(R"(
+
   Video Only:)");
 #endif
     printf(R"(
+
   - wf-recorder                         Records the video. Use Ctrl+C to stop recording.
                                         The video file will be stored as recording.mp4 in the
                                         current working directory.
+
   - wf-recorder -f <filename>.ext       Records the video. Use Ctrl+C to stop recording.
                                         The video file will be stored as <outputname>.ext in the
                                         current working directory.)");
 #ifdef HAVE_PULSE
     printf(R"(
-
 
   Video and Audio:
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -527,7 +527,7 @@ With no FILE, start recording the current screen.)");
 
   -R, --sample-rate         Changes the audio sample rate, in HZ. The default value is 44100. 
 
-  -X, --sample-format       Set the audio sample format. These can be found by running: 
+  -X, --sample-format       Set the output audio sample format. These can be found by running: 
                             *ffmpeg -sample_fmts*
 
   -P, --acodec-param        Change the audio codec parameters.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -514,9 +514,24 @@ With no FILE, start recording the current screen.)");
     printf(R"(
 
   -c, --codec               Specifies the codec of the video. Supports  GIF output also.
-                            To modify codec parameters, use -p <option_name>=<option_value>
+
+  -r, --framerate           Changes an approximation of the video framerate. The default is 60. 
+
+  -x, --pixel-format        Set the output pixel format. These can be found by running:
+                            *ffmpeg -pix_fmts*
+
+  -p, --codec-param         Change the video codec parameters.
+                            -p <option_name>=<option_value>)
 
   -C, --acodec              Specifies the codec of the audio. 
+
+  -R, --sample-rate         Changes the audio sample rate, in HZ. The default value is 44100. 
+
+  -X, --sample-format       Set the audio sample format. These can be found by running: 
+                            *ffmpeg -sample_fmts*
+
+  -P, --acodec-param        Change the audio codec parameters.
+                            -P <option_name>=<option_value>)
 
   -d, --device              Selects the device to use when encoding the video
                             Some drivers report support for rgb0 data for vaapi input but
@@ -532,22 +547,13 @@ With no FILE, start recording the current screen.)");
   -m, --muxer               Set the output format to a specific muxer instead of detecting it
                             from the filename.
 
-  -x, --pixel-format        Set the output pixel format. These can be found by running:
-                            *ffmpeg -pix_fmts*
-
-  -X, --sample-format       Set the audio sample format. These can be found by running: 
-                            *ffmpeg -sample_fmts*
-
   -g, --geometry            Selects a specific part of the screen.
 
   -h, --help                Prints this help screen.
 
   -l, --log                 Generates a log on the current terminal. Debug purposes.
 
-  -o, --output              Specify the output where the video is to be recorded.
-
-  -p, --codec-param         Change the codec parameters.
-                            -p <option_name>=<option_value>)");
+  -o, --output              Specify the output where the video is to be recorded.");
 #ifdef HAVE_OPENCL
     printf(R"(
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -345,7 +345,7 @@ static void write_loop(FrameWriterParams params)
             if (params.enable_audio)
             {
                 pulseParams.audio_frame_size = frame_writer->get_audio_buffer_size();
-		pulseParams.sample_rate = params.sample_rate;
+                pulseParams.sample_rate = params.sample_rate;
                 pr = std::unique_ptr<PulseReader> (new PulseReader(pulseParams));
                 pr->start();
             }
@@ -553,14 +553,14 @@ With no FILE, start recording the current screen.)");
 
   -l, --log                 Generates a log on the current terminal. Debug purposes.
 
-  -o, --output              Specify the output where the video is to be recorded.");
+  -o, --output              Specify the output where the video is to be recorded.)");
 #ifdef HAVE_OPENCL
     printf(R"(
 
   -e, --opencl              Use the -e[#] or --opencl[=#] in conjunction with -t or --force-yuv option
                             to use opencl for gpu accelerated conversion of data to yuv. # is one
                             of the devices listed when running without specifying #.)");
-//#endif
+#endif
     printf(R"(
 
   -t, --force-yuv           Use the -t or --force-yuv option to force conversion of the data to
@@ -630,12 +630,12 @@ int main(int argc, char *argv[])
         { "geometry",        required_argument, NULL, 'g' },
         { "codec",           required_argument, NULL, 'c' },
         { "codec-param",     required_argument, NULL, 'p' },
-	{ "framerate",       required_argument, NULL, 'r' },
+        { "framerate",       required_argument, NULL, 'r' },
         { "pixel-format",    required_argument, NULL, 'x' },
-	{ "acodec",          required_argument, NULL, 'C' },
-	{ "acodec-param",    required_argument, NULL, 'P' },
-	{ "sample-rate",     required_argument, NULL, 'R' },
-	{ "sample-format",   required_argument, NULL, 'X' },
+        { "acodec",          required_argument, NULL, 'C' },
+        { "acodec-param",    required_argument, NULL, 'P' },
+        { "sample-rate",     required_argument, NULL, 'R' },
+        { "sample-format",   required_argument, NULL, 'X' },
         { "device",          required_argument, NULL, 'd' },
         { "log",             no_argument,       NULL, 'l' },
         { "audio",           optional_argument, NULL, 'a' },
@@ -673,9 +673,9 @@ int main(int argc, char *argv[])
                 params.codec = optarg;
                 break;
 
-	    case 'r':
-	        params.framerate = atoi(optarg);
-	 	break;
+            case 'r':
+                params.framerate = atoi(optarg);
+                break;
 
             case 'x':
                 params.pix_fmt = optarg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -517,7 +517,7 @@ With no FILE, start recording the current screen.)");
 
   -r, --framerate           Changes an approximation of the video framerate.
 
-  -x, --pixel-format        Set the output pixel format. These can be found by running:
+  -x, --pixel-format        Set the output video pixel format. These can be found by running:
                             *ffmpeg -pix_fmts*
 
   -p, --codec-param         Change the video codec parameters.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -560,7 +560,7 @@ With no FILE, start recording the current screen.)");
   -e, --opencl              Use the -e[#] or --opencl[=#] in conjunction with -t or --force-yuv option
                             to use opencl for gpu accelerated conversion of data to yuv. # is one
                             of the devices listed when running without specifying #.)");
-#endif
+//#endif
     printf(R"(
 
   -t, --force-yuv           Use the -t or --force-yuv option to force conversion of the data to

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,7 +610,6 @@ int main(int argc, char *argv[])
     params.framerate = DEFAULT_FRAMERATE;
     params.acodec = DEFAULT_ACODEC;
     params.sample_rate = DEFAULT_SAMPLE_RATE;
-    //params.sample_fmt = DEFAULT_SAMPLE_FMT;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
     params.force_yuv = false;

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -20,7 +20,7 @@ PulseReader::PulseReader(PulseReaderParams _p)
     pa_sample_spec sample_spec =
     {
         .format = PA_SAMPLE_FLOAT32LE,
-        .rate = 44100,
+        .rate = params.sample_rate,
         .channels = 2,
     };
 

--- a/src/pulse.hpp
+++ b/src/pulse.hpp
@@ -8,6 +8,7 @@
 struct PulseReaderParams
 {
     size_t audio_frame_size;
+    uint32_t sample_rate;
     /* Can be NULL */
     char *audio_source;
 };


### PR DESCRIPTION
This is a WIP fix for issue 100: https://github.com/ammen99/wf-recorder/issues/100. 

It also adds some general improvements like adding a video framerate option, and making options consistent between audio and video. 

The first stage just adds an audio codec option, but the second stage, after I add it, will add support for changing the audio codec, sample format, sample rate, and frame rate. It is not finished, however, as my change of sample format most likely breaks a function which I do not understand. 