### PR TITLE
Add missing av_hwframe_constraints_free.

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -59,6 +59,7 @@ void FrameWriter::init_hw_accel()
     ctx->height = params.height;
     ctx->format = cst->valid_hw_formats[0];
     ctx->sw_format = AV_PIX_FMT_NV12;
+    av_hwframe_constraints_free(&cst);
 
     if ((ret = av_hwframe_ctx_init(hw_frame_context)))
     {


### PR DESCRIPTION
According to ffmpeg's docs a call to av_hwdevice_get_hwframe_constraints
has to be followed by another call to av_hwframe_constraints_free to
free allocated resources.