### PR TITLE
docs: adds useful bits from README to man page.

### DIFF
--- a/manpage/wf-recorder.1.scd
+++ b/manpage/wf-recorder.1.scd
@@ -8,6 +8,10 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 
 *wf-recorder* [options...] -f [file]
 
+In its simplest form, run `wf-recorder` to start recording and use Ctrl+C to stop.
+This will create a file called `recording.mp4` in the current working directory using
+the default codec.
+
 # OPTIONS
 *-a, --audio [DEVICE]*
 	Starts recording the screen with audio.
@@ -61,7 +65,9 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 	*-p <option_name>=<option_value>*
 
 *-e, --opencl [DEVICE]*
-	Uses opencl to do RGB to YUV conversion on the GPU.
+	Attempts to use OpenCL if wf-recorder was built with OpenCL support and `-t`
+	or `--force-yuv` are specified, even without vaapi GPU encoding. Use `-e#` or `--opencl=#`
+	to use a specific OpenCL device, where `#` is one of the devices listed.
 
 *-t, --force-yuv*
 	Use the -t or --force-yuv option in addition to the vaapi options to convert the data in software,
@@ -73,6 +79,46 @@ wf-recorder - A simple screen recording program for wlroots-based compositors
 # DESCRIPTION
 *wf-recorder* is a tool built to record your screen on Wayland compositors.
 It makes use of wlr-screencopy for capturing video and FFmpeg for encoding it.
+
+# EXAMPLES
+
+To select a specific part of the screen you can either use `-g <geometry>`, or
+use https://github.com/emersion/slurp for interactive selection of the
+screen area that will be recorded:
+
+```
+wf-recorder -g "$(slurp)"
+```
+
+You can record screen and sound simultaneously with
+
+```
+wf-recorder --audio --file=recording_with_audio.mp4
+```
+
+To specify a codec, use the `-c <codec>` option. To modify codec parameters,
+use `-p <option_name>=<option_value>`.
+
+To set a specific output format, use the `--muxer` option. For example, to
+output to a video4linux2 loopback you might use:
+
+```
+wf-recorder --muxer=v4l2 --codec=rawvideo --file=/dev/video2
+```
+
+To use GPU encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU
+device to use with the `-d` option:
+
+```
+wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
+```
+
+Some drivers report support for rgb0 data for vaapi input but really only
+support yuv planar formats. In this case, use the `-t` or `--force-yuv` option
+in addition to the vaapi options to convert the data to yuv planar data before
+sending it to the GPU.
+
+
 
 # SEE ALSO
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -519,7 +519,9 @@ static void help()
     printf(R"(Usage: wf-recorder [OPTION]... -f [FILE]...
 Screen recording of wlroots-based compositors
 
-With no FILE, start recording the current screen.)");
+With no FILE, start recording the current screen.
+
+Use Ctrl+C to stop.)");
 #ifdef HAVE_PULSE
     printf(R"(
 


### PR DESCRIPTION
Knowing how to STOP `wf-recorder` is critical and was missing from the
man page.

The README had several other useful tips as well which werent in the man
page.

You shouldn't have to read both to get complete docs.
