### PR TITLE
Replace `sinks` with `sources` in help for --audio

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -529,7 +529,7 @@ Use Ctrl+C to stop.)");
                             [DEVICE] argument is optional.
                             In case you want to specify the pulseaudio device which will capture
                             the audio, you can run this command with the name of that device.
-                            You can find your device by running: pactl list sinks | grep Name)");
+                            You can find your device by running: pactl list sources | grep Name)");
 #endif
     printf(R"(
 


### PR DESCRIPTION
I understand this is what's intended. I don't have any deep understanding of pulseaudio, but It's what worked for me and, as pointed out to me in #119, what is actually in this repo's wiki.

Closes #119