### PR TITLE
Remove space in help in between -a and [DEVICE]

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ You can record screen and sound simultaneously with
 wf-recorder --audio --file=recording_with_audio.mp4
 ```
 
+To specify an audio device, use the `-a<device>` option.
+
 To specify a codec, use the `-c <codec>` option. To modify codec parameters, use `-p <option_name>=<option_value>`.
 
 To set a specific output format, use the `--muxer` option. For example, to output to a video4linux2 loopback you might use:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -542,7 +542,7 @@ Use Ctrl+C to stop.)");
 #ifdef HAVE_PULSE
     printf(R"(
 
-  -a, --audio [DEVICE]      Starts recording the screen with audio.
+  -a, --audio[DEVICE]       Starts recording the screen with audio.
                             [DEVICE] argument is optional.
                             In case you want to specify the pulseaudio device which will capture
                             the audio, you can run this command with the name of that device.


### PR DESCRIPTION
As it has otherwise no effect. I made a note in README as well.

_ _ _ _

Not sure this is correct approach, but also I don't know how to fix this other way in https://github.com/ammen99/wf-recorder/blob/master/src/main.cpp#L693, nor how to report an the unknown arg - this may be a bug.

I didn't edit this in man pages as well, as I'm unsure what's the proper way.

Note that there's a secondary issue- no error is thrown when the device is specified (and ignored), separated by a space (iow as another arg). 

Thanks for a great program!