### PR TITLE
don't ask for overwrite for the char device

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -577,7 +577,7 @@ void handle_graceful_termination(int)
 static bool user_specified_overwrite(std::string filename)
 {
     struct stat buffer;   
-    if (stat (filename.c_str(), &buffer) == 0)
+    if (stat (filename.c_str(), &buffer) == 0 && !S_ISCHR(buffer.st_mode))
     {
         std::string input;
         std::cout << "Output file \"" << filename << "\" exists. Overwrite? Y/n: ";


### PR DESCRIPTION
`/dev/videoX` should always exists for the `--muxer=v4l2`, don't ask permission to override it. Fixes #140 .