### PR TITLE
Add support for 565 and 2101010 formats

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -92,6 +92,14 @@ AVPixelFormat FrameWriter::get_input_format()
         return AV_PIX_FMT_RGB565LE;
     case INPUT_FORMAT_BGR565:
         return AV_PIX_FMT_BGR565LE;
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(56, 55, 100)
+    case INPUT_FORMAT_X2RGB10:
+        return AV_PIX_FMT_X2RGB10LE;
+#endif
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 7, 100)
+    case INPUT_FORMAT_X2BGR10:
+        return AV_PIX_FMT_X2BGR10LE;
+#endif
     default:
         std::cerr << "Unknown format: " << params.format << std::endl;
         std::exit(-1);

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -88,6 +88,10 @@ AVPixelFormat FrameWriter::get_input_format()
         return AV_PIX_FMT_RGB0;
     case INPUT_FORMAT_BGR8:
         return AV_PIX_FMT_RGB24;
+    case INPUT_FORMAT_RGB565:
+        return AV_PIX_FMT_RGB565LE;
+    case INPUT_FORMAT_BGR565:
+        return AV_PIX_FMT_BGR565LE;
     default:
         std::cerr << "Unknown format: " << params.format << std::endl;
         std::exit(-1);

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -39,6 +39,8 @@ enum InputFormat
     INPUT_FORMAT_BGR8,
     INPUT_FORMAT_RGB565,
     INPUT_FORMAT_BGR565,
+    INPUT_FORMAT_X2RGB10,
+    INPUT_FORMAT_X2BGR10,
 };
 
 struct FrameWriterParams

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -34,9 +34,11 @@ extern "C"
 
 enum InputFormat
 {
-     INPUT_FORMAT_BGR0,
-     INPUT_FORMAT_RGB0,
-     INPUT_FORMAT_BGR8
+    INPUT_FORMAT_BGR0,
+    INPUT_FORMAT_RGB0,
+    INPUT_FORMAT_BGR8,
+    INPUT_FORMAT_RGB565,
+    INPUT_FORMAT_BGR565,
 };
 
 struct FrameWriterParams

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -312,6 +312,12 @@ static InputFormat get_input_format(wf_buffer& buffer)
         return INPUT_FORMAT_RGB565;
     case WL_SHM_FORMAT_BGR565:
         return INPUT_FORMAT_BGR565;
+    case WL_SHM_FORMAT_ARGB2101010:
+    case WL_SHM_FORMAT_XRGB2101010:
+        return INPUT_FORMAT_X2RGB10;
+    case WL_SHM_FORMAT_ABGR2101010:
+    case WL_SHM_FORMAT_XBGR2101010:
+        return INPUT_FORMAT_X2BGR10;
     default:
         fprintf(stderr, "Unsupported buffer format %d, exiting.", buffer.format);
         std::exit(0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -308,6 +308,10 @@ static InputFormat get_input_format(wf_buffer& buffer)
         return INPUT_FORMAT_RGB0;
     case WL_SHM_FORMAT_BGR888:
         return INPUT_FORMAT_BGR8;
+    case WL_SHM_FORMAT_RGB565:
+        return INPUT_FORMAT_RGB565;
+    case WL_SHM_FORMAT_BGR565:
+        return INPUT_FORMAT_BGR565;
     default:
         fprintf(stderr, "Unsupported buffer format %d, exiting.", buffer.format);
         std::exit(0);


### PR DESCRIPTION
This PR makes it possible to record the screen when the compositor provides 5-bit-per-channel or 10-bpc screenshot data instead of the usual 8-bpc.

This PR partially addresses #155 ; it does not add 16-unsigned-bpc and 16-float-bpc formats, since I don't have 16-unsigned working properly in mesa and wlroots yet, and FFmpeg does not yet support 16-float .

While the changes here are relatively simple, actually testing that the new formats work is tricky.

The 2101010 formats are only available if you use a recent (~~git~~ now 5.0) version of FFmpeg. To test the X2BGR format, install Sway ~~from git (or wait until 1.7 is released)~~ version 1.7, and run the `swaymsg output '*' render_bit_depth 10` command to increase the bit depth at which the screen is rendered.  Then `wf-recorder` should be given screencopy buffers with 10-bpc data.

To test the RGB565 format, build Sway from the [`mstoeckl/sway/extra-bit-depths`](https://github.com/mstoeckl/sway/tree/extra-bit-depths) branch, run `swaymsg output '*' render_bit_depth 5`; and then run `wf-recorder`.


