### PR TITLE
Add support for WL_SHM_FORMAT_BGR888, closes #169

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -81,8 +81,17 @@ bool is_fmt_supported(AVPixelFormat fmt, const AVPixelFormat *supported)
 
 AVPixelFormat FrameWriter::get_input_format()
 {
-    return params.format == INPUT_FORMAT_BGR0 ?
-        AV_PIX_FMT_BGR0 : AV_PIX_FMT_RGB0;
+    switch (params.format) {
+    case INPUT_FORMAT_BGR0:
+        return AV_PIX_FMT_BGR0;
+    case INPUT_FORMAT_RGB0:
+        return AV_PIX_FMT_RGB0;
+    case INPUT_FORMAT_BGR8:
+        return AV_PIX_FMT_RGB24;
+    default:
+        std::cerr << "Unknown format: " << params.format << std::endl;
+        std::exit(-1);
+    }
 }
 
 AVPixelFormat FrameWriter::lookup_pixel_format(std::string pix_fmt)

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -35,7 +35,8 @@ extern "C"
 enum InputFormat
 {
      INPUT_FORMAT_BGR0,
-     INPUT_FORMAT_RGB0
+     INPUT_FORMAT_RGB0,
+     INPUT_FORMAT_BGR8
 };
 
 struct FrameWriterParams

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -299,18 +299,19 @@ static int next_frame(int frame)
 
 static InputFormat get_input_format(wf_buffer& buffer)
 {
-    if (buffer.format == WL_SHM_FORMAT_ARGB8888)
+    switch (buffer.format) {
+    case WL_SHM_FORMAT_ARGB8888:
+    case WL_SHM_FORMAT_XRGB8888:
         return INPUT_FORMAT_BGR0;
-    if (buffer.format == WL_SHM_FORMAT_XRGB8888)
-        return INPUT_FORMAT_BGR0;
-
-    if (buffer.format == WL_SHM_FORMAT_XBGR8888)
+    case WL_SHM_FORMAT_XBGR8888:
+    case WL_SHM_FORMAT_ABGR8888:
         return INPUT_FORMAT_RGB0;
-    if (buffer.format == WL_SHM_FORMAT_ABGR8888)
-        return INPUT_FORMAT_RGB0;
-
-    fprintf(stderr, "Unsupported buffer format %d, exiting.", buffer.format);
-    std::exit(0);
+    case WL_SHM_FORMAT_BGR888:
+        return INPUT_FORMAT_BGR8;
+    default:
+        fprintf(stderr, "Unsupported buffer format %d, exiting.", buffer.format);
+        std::exit(0);
+    }
 }
 
 static void write_loop(FrameWriterParams params)


### PR DESCRIPTION
This PR adds support for the `WL_SHM_FORMAT_BGR888` format used by the Nvidia driver when using GBM on wayland. Also refactored multiple `if`s into a `switch`es.
`AV_PIX_FMT_RGB24` seems to produce the exact colors as a regular recording on eglstreams with Nvidia so hopefully it's the correct one (`AV_PIX_FMT_BGR24` gave inaccurate colors).