### PR TITLE
Set sample rate to 48000 to match Pipewire defaults

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -13,7 +13,7 @@
 
 
 static const AVRational US_RATIONAL{1,1000000} ;
-#define AUDIO_RATE 44100
+#define AUDIO_RATE 48000
 
 // av_register_all was deprecated in 58.9.100, removed in 59.0.100
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 0, 100)

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -13,7 +13,6 @@
 
 
 static const AVRational US_RATIONAL{1,1000000} ;
-#define AUDIO_RATE 48000
 
 // av_register_all was deprecated in 58.9.100, removed in 59.0.100
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 0, 100)

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -11,7 +11,7 @@
 #include <atomic>
 #include "config.h"
 
-#define AUDIO_RATE 44100
+#define AUDIO_RATE 48000
 
 extern "C"
 {

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -20,7 +20,7 @@ PulseReader::PulseReader(PulseReaderParams _p)
     pa_sample_spec sample_spec =
     {
         .format = PA_SAMPLE_FLOAT32LE,
-        .rate = 44100,
+        .rate = 48000,
         .channels = 2,
     };
 

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -20,7 +20,7 @@ PulseReader::PulseReader(PulseReaderParams _p)
     pa_sample_spec sample_spec =
     {
         .format = PA_SAMPLE_FLOAT32LE,
-        .rate = 48000,
+        .rate = AUDIO_RATE,
         .channels = 2,
     };
 


### PR DESCRIPTION
Alternative solution is to add 44100 in `default.clock.allowed-rates` in pipewire.conf. Better solution is to wait for #102 to be merged

Fixes #59 and other similar issues