### PR TITLE
Remove unused variable

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -735,8 +735,6 @@ int main(int argc, char *argv[])
     };
 
     int c, i;
-    std::string param;
-    size_t pos;
     while((c = getopt_long(argc, argv, "o:f:m:g:c:p:r:x:C:P:R:X:d:b:la::thvDF:", opts, &i)) != -1)
     {
         switch(c)


### PR DESCRIPTION
Mostly squelching a built-time warning.