### PR TITLE
fix buffersink pix_fmt handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ To use GPU encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU 
 ```
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
-Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-t` or `--force-yuv` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the GPU.
+Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-x yuv420p` or `--pixel-format yuv420p` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the GPU.

--- a/manpage/wf-recorder.1
+++ b/manpage/wf-recorder.1
@@ -1,4 +1,4 @@
-.Dd $Mdocdate: July 26 2022 $
+.Dd $Mdocdate: July 30 2022 $
 .Dt WF-RECORDER 1
 .Os
 .Sh NAME
@@ -6,7 +6,7 @@
 .Nd simple screen recording program for wlroots-based compositors
 .Sh SYNOPSIS
 .Nm wf-recorder
-.Op Fl abcCdDefFghlmopPrRtvxX
+.Op Fl abcCdDefFghlmopPrRvxX
 .Op Fl a, -audio Op Ar =DEVICE
 .Op Fl b, -bframes Ar max_b_frames
 .Op Fl c, -codec Ar output_codec
@@ -21,7 +21,6 @@
 .Op Fl m, -muxer Ar muxer
 .Op Fl o, -output Ar output
 .Op Fl p, -codec-param Op Ar option_param=option_value
-.Op Fl t, -force-yuv
 .Op Fl v, -version
 .Op Fl x, -pixel-format
 .Op Fl C, -audio-codec Ar output_audio_codec
@@ -82,7 +81,7 @@ Some drivers report support for
 .Ql rgb0
 data for vaapi input but really only support yuv.
 Use the
-.Fl t , -force-yuv
+.Fl x yuv420 , -pixel-format yuv420p
 option in addition to the vaapi options to convert the
 data in software, before sending it to the GPU.
 .Pp
@@ -128,10 +127,6 @@ Specify the output where the video is to be recorded.
 .Pp
 .It Fl p , -codec-param Op Ar option_name=option_value
 Change the codec parameters.
-.Pp
-.It Fl t , -force-yuv
-Use this option in addition to the vaapi options to convert
-the data in software, before sending it to the GPU.
 .Pp
 .It Fl v , -version
 Print the version of wf-recorder.
@@ -206,7 +201,7 @@ data for
 .Ql vaapi
 input but really only support yuv planar formats.
 In this case, use the
-.Fl t , -force-yuv
+.Fl x yuv420p
 option in addition to the
 .Ql vaapi
 options to convert the data to yuv planar data before sending it to the GPU.

--- a/manpage/wf-recorder.1
+++ b/manpage/wf-recorder.1
@@ -62,16 +62,13 @@ You can find your device by running
 .It Fl b , -bframes Ar max_b_frames
 Sets the maximum number of B-Frames to use.
 .Pp
-.It Fl c , -codec
-.Ar output_codec
+.It Fl c , -codec Ar output_codec
 Specifies the codec of the video. Supports GIF output as well.
 .Pp
 To modify codec parameters, use
-.Fl p
-.Ar option_name=option_value
+.Fl p Ar option_name=option_value
 .Pp
-.It Fl r , -framerate
-.Ar framerate
+.It Fl r , -framerate Ar framerate
 Changes an approximation of the video framerate. The default is 60.
 .Pp
 .It Fl d , -device Ar encoding_device
@@ -81,7 +78,7 @@ Some drivers report support for
 .Ql rgb0
 data for vaapi input but really only support yuv.
 Use the
-.Fl x yuv420 , -pixel-format yuv420p
+.Fl x Ar yuv420
 option in addition to the vaapi options to convert the
 data in software, before sending it to the GPU.
 .Pp
@@ -137,18 +134,17 @@ Set the output pixel format.
 List available formats using
 .Dl $ ffmpeg -pix_fmts
 .Pp
-.It Fl C , -audio-codec
-.Ar output_audio_codec
+.It Fl C , -audio-codec Ar output_audio_codec
 Specifies the codec of the audio.
 .Pp
 .It Fl P , -audio-codec-param Op Ar option_name=option_value
 Change the audio codec parameters.
 .Pp
-.It Fl R , -sample-rate
-.Ar sample_rate
+.It Fl R , -sample-rate Ar sample_rate
 Changes the audio sample rate, in HZ. The default value is 48000.
 .Pp
-.It Fl X , -sample-format Ar sample_format Set the output audio sample format.
+.It Fl X , -sample-format Ar sample_format
+Set the output audio sample format.
 .Pp
 List available formats using
 .Dl $ ffmpeg -sample_fmts
@@ -180,10 +176,10 @@ option. To modify codec parameters,
 .Ar option_name=option_value.
 .Pp
 To set a specific output format, use the
-.Fl m muxer
+.Fl m, muxer
 option. For example, to
-output to a v
-.Sy ideo4linux2
+output to a
+.Sy video4linux2
 loopback you might use:
 .Dl $ wf-recorder --muxer=v4l2 --codec=rawvideo --file=/dev/video2
 .Pp
@@ -201,7 +197,7 @@ data for
 .Ql vaapi
 input but really only support yuv planar formats.
 In this case, use the
-.Fl x yuv420p
+.Fl x Ar yuv420p
 option in addition to the
 .Ql vaapi
 options to convert the data to yuv planar data before sending it to the GPU.

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -128,17 +128,6 @@ AVPixelFormat FrameWriter::lookup_pixel_format(std::string pix_fmt)
 AVPixelFormat FrameWriter::handle_buffersink_pix_fmt(const AVCodec *codec)
 {
 
-    // Force pixel format to yuv420p if requested and possible
-    if (params.force_yuv) {
-        if (!codec->pix_fmts ||
-            is_fmt_supported(AV_PIX_FMT_YUV420P, codec->pix_fmts)) {
-            return AV_PIX_FMT_YUV420P;
-        } else {
-            std::cerr << "Ignoring request to force yuv420p, " <<
-                "because it is not supported by the codec\n";
-        }
-    }
-
     // Return with user chosen format
     if (!params.pix_fmt.empty())
         return lookup_pixel_format(params.pix_fmt);

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -94,7 +94,7 @@ class FrameWriter
     AVBufferRef *hw_frame_context = NULL;
 
     AVPixelFormat lookup_pixel_format(std::string pix_fmt);
-    AVPixelFormat choose_sw_format(const AVCodec *codec);
+    AVPixelFormat handle_buffersink_pix_fmt(const AVCodec *codec);
     AVPixelFormat get_input_format();
     void init_hw_accel();
     void init_codecs();

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -68,7 +68,6 @@ struct FrameWriterParams
     bool enable_audio;
     bool enable_ffmpeg_debug_output;
 
-    bool force_yuv;
     int bframes;
 
     std::atomic<bool>& write_aborted_flag;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -602,9 +602,6 @@ Use Ctrl+C to stop.)");
   -F, --filter              Specify the ffmpeg filter string to use. For example,
                             -F hwupload,scale_vaapi=format=nv12 is used for VAAPI.
 
-  -t, --force-yuv           Use the -t or --force-yuv option to force conversion of the data to
-                            yuv format, before sending it to the gpu.
-  
   -b, --bframes             This option is used to set the maximum number of b-frames to be used.
                             If b-frames are not supported by your hardware, set this to 0.
   
@@ -707,7 +704,6 @@ int main(int argc, char *argv[])
     params.sample_rate = DEFAULT_AUDIO_SAMPLE_RATE;
     params.enable_ffmpeg_debug_output = false;
     params.enable_audio = false;
-    params.force_yuv = false;
     params.bframes = -1;
 
     constexpr const char* default_cmdline_output = "interactive";
@@ -731,7 +727,6 @@ int main(int argc, char *argv[])
         { "log",               no_argument,       NULL, 'l' },
         { "audio",             optional_argument, NULL, 'a' },
         { "help",              no_argument,       NULL, 'h' },
-        { "force-yuv",         no_argument,       NULL, 't' },
         { "bframes",           required_argument, NULL, 'b' },
         { "version",           no_argument,       NULL, 'v' },
         { "no-damage",         no_argument,       NULL, 'D' },
@@ -739,7 +734,7 @@ int main(int argc, char *argv[])
     };
 
     int c, i;
-    while((c = getopt_long(argc, argv, "o:f:m:g:c:p:r:x:C:P:R:X:d:b:la::thvDF:", opts, &i)) != -1)
+    while((c = getopt_long(argc, argv, "o:f:m:g:c:p:r:x:C:P:R:X:d:b:la::hvDF:", opts, &i)) != -1)
     {
         switch(c)
         {
@@ -807,10 +802,6 @@ int main(int argc, char *argv[])
                 std::cerr << "Cannot record audio. Built without pulse support." << std::endl;
                 return EXIT_FAILURE;
 #endif
-                break;
-
-            case 't':
-                params.force_yuv = true;
                 break;
 
             case 'h':


### PR DESCRIPTION
There was a bug caused by 5384bc9f3691833b5bf63e97afb953eadfbbec90 which
caused wf-recorder to select incorrect pix_fmt for buffersink, and
to ignore -x/--pixel_format. This is fixed by using the internal
choose_sw_format() function again.

Also I'm unsure what the point of --force-yuv being available was when the user can just set it with --pixel-format anyway. Shouldn't this just be removed in favor of suggesting "--pixel-format yuv420p" instead?