### PR TITLE
Use VP9+Opus on MKV by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ git clone https://github.com/ammen99/wf-recorder.git && cd wf-recorder
 meson build --prefix=/usr --buildtype=release
 ninja -C build
 ```
-Optionally configure with `-Ddefault_codec='codec'`. The default is libx264. Now you can just run `./build/wf-recorder` or install it with `sudo ninja -C build install`.
+Optionally configure with `-Ddefault_codec='codec'`. The default is libvpx-vp9. Now you can just run `./build/wf-recorder` or install it with `sudo ninja -C build install`.
 
 The man page can be read with `man ./manpage/wf-recorder.1`.
 
 # Usage
-In its simplest form, run `wf-recorder` to start recording and use Ctrl+C to stop. This will create a file called `recording.mp4` in the current working directory using the default codec.
+In its simplest form, run `wf-recorder` to start recording and use Ctrl+C to stop. This will create a file called `recording.mkv` in the current working directory using the default codec.
 
 Use `-f <filename>` to specify the output file. In case of multiple outputs, you'll first be prompted to select the output you want to record. If you know the output name beforehand, you can use the `-o <output name>` option.
 
@@ -81,7 +81,7 @@ wf-recorder -g "$(slurp)"
 You can record screen and sound simultaneously with
 
 ```
-wf-recorder --audio --file=recording_with_audio.mp4
+wf-recorder --audio --file=recording_with_audio.mkv
 ```
 
 To specify an audio device, use the `-a<device>` or `--audio=<device>` options.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ xbps-install -S wf-recorder
 
 ## Fedora Linux
 
-Fedora users can install from rpmfusion-free-updates. First [enable rpmfusion](https://rpmfusion.org/Configuration) and then
+Fedora users can install wf-recorder from the official repos
 ```
 sudo dnf install wf-recorder
 ```
@@ -54,7 +54,7 @@ sudo apt install libavutil-dev libavcodec-dev libavformat-dev libswscale-dev lib
 
 #### Fedora
 ```
-$ sudo dnf install wayland-devel wayland-protocols-devel ffmpeg-devel
+$ sudo dnf install wayland-devel wayland-protocols-devel ffmpeg-free-devel
 ```
 
 ### Download & Build

--- a/config.h.in
+++ b/config.h.in
@@ -4,6 +4,7 @@
 #define DEFAULT_FRAMERATE @default_framerate@
 #define DEFAULT_AUDIO_CODEC "@default_audio_codec@"
 #define DEFAULT_AUDIO_SAMPLE_RATE @default_audio_sample_rate@
+#define DEFAULT_CONTAINER_FORMAT @default_container_format@
 #define FALLBACK_AUDIO_SAMPLE_FMT "@fallback_audio_sample_fmt@"
 #mesondefine HAVE_PULSE
 #mesondefine HAVE_OPENCL

--- a/manpage/wf-recorder.1
+++ b/manpage/wf-recorder.1
@@ -42,7 +42,7 @@ to start recording and use
 .Ql Ctrl+C
 to stop.
 This will create a file called
-.Ql recording.mp4
+.Ql recording.mkv
 in the current working directory using the default
 .Ar codec.
 .Pp
@@ -159,7 +159,7 @@ screen area that will be recorded:
 .Dl $ wf-recorder -g "$(slurp)"
 .Pp
 You can record screen and sound simultaneously with
-.Dl $ wf-recorder --audio --file=recording_with_audio.mp4
+.Dl $ wf-recorder --audio --file=recording_with_audio.mkv
 .Pp
 To specify an audio device, use the
 .Fl -a<DEVICE>
@@ -184,12 +184,12 @@ loopback you might use:
 .Dl $ wf-recorder --muxer=v4l2 --codec=rawvideo --file=/dev/video2
 .Pp
 To use GPU encoding, use a VAAPI codec (for ex.
-.Ql h264_vaapi
+.Ql vp9_vaapi
 ) and specify a GPU
 device to use with the
 .Fl d
 option:
-.Dl $ wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
+.Dl $ wf-recorder -f test-vaapi.mkv -c vp9_vaapi -d /dev/dri/renderD128
 .Pp
 Some drivers report support for
 .Ql rgb0

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ conf_data.set('default_codec', get_option('default_codec'))
 conf_data.set('default_framerate', get_option('default_framerate'))
 conf_data.set('default_audio_codec', get_option('default_audio_codec'))
 conf_data.set('default_audio_sample_rate', get_option('default_audio_sample_rate'))
+conf_data.set('default_container_format', get_option('default_container_format'))
 conf_data.set('fallback_audio_sample_fmt', get_option('fallback_audio_sample_fmt'))
 
 version = '"@0@"'.format(meson.project_version())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,5 +2,6 @@ option('default_codec', type: 'string', value: 'libvpx-vp9', description: 'Codec
 option('default_framerate', type: 'integer', value: 60, description: 'Video framerate that will be used by default')
 option('default_audio_codec', type: 'string', value: 'libopus', description: 'Audio codec that will be used by default')
 option('default_audio_sample_rate', type: 'integer', value: 48000, description: 'Audio sample rate that will be used by default')
+option('default_container_format', type: 'string', value: 'mkv', description: 'Container file format that will be used by default')
 option('fallback_audio_sample_fmt', type: 'string', value: 's16', description: 'Fallback audio sample format that will be used if wf-recorder cannot determine the sample formats supported by a codec')
 option('pulse', type: 'feature', value: 'auto', description: 'Enable Pulseaudio')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
-option('default_codec', type: 'string', value: 'libx264', description: 'Codec that will be used by default')
+option('default_codec', type: 'string', value: 'libvpx-vp9', description: 'Codec that will be used by default')
 option('default_framerate', type: 'integer', value: 60, description: 'Video framerate that will be used by default')
-option('default_audio_codec', type: 'string', value: 'aac', description: 'Audio codec that will be used by default')
+option('default_audio_codec', type: 'string', value: 'libopus', description: 'Audio codec that will be used by default')
 option('default_audio_sample_rate', type: 'integer', value: 48000, description: 'Audio sample rate that will be used by default')
 option('fallback_audio_sample_fmt', type: 'string', value: 's16', description: 'Fallback audio sample format that will be used if wf-recorder cannot determine the sample formats supported by a codec')
 option('pulse', type: 'feature', value: 'auto', description: 'Enable Pulseaudio')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -697,7 +697,7 @@ static void parse_codec_opts(std::map<std::string, std::string>& options, const 
 int main(int argc, char *argv[])
 {
     FrameWriterParams params = FrameWriterParams(exit_main_loop);
-    params.file = "recording.mkv";
+    params.file = "recording" + "." + DEFAULT_CONTAINER_FORMAT;
     params.codec = DEFAULT_CODEC;
     params.framerate = DEFAULT_FRAMERATE;
     params.audio_codec = DEFAULT_AUDIO_CODEC;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -626,7 +626,7 @@ Examples:)");
     printf(R"(
 
   - wf-recorder                         Records the video. Use Ctrl+C to stop recording.
-                                        The video file will be stored as recording.mp4 in the
+                                        The video file will be stored as recording.mkv in the
                                         current working directory.
 
   - wf-recorder -f <filename>.ext       Records the video. Use Ctrl+C to stop recording.
@@ -638,7 +638,7 @@ Examples:)");
   Video and Audio:
 
   - wf-recorder -a                      Records the video and audio. Use Ctrl+C to stop recording.
-                                        The video file will be stored as recording.mp4 in the
+                                        The video file will be stored as recording.mkv in the
                                         current working directory.
 
   - wf-recorder -a -f <filename>.ext    Records the video and audio. Use Ctrl+C to stop recording.
@@ -697,7 +697,7 @@ static void parse_codec_opts(std::map<std::string, std::string>& options, const 
 int main(int argc, char *argv[])
 {
     FrameWriterParams params = FrameWriterParams(exit_main_loop);
-    params.file = "recording.mp4";
+    params.file = "recording.mkv";
     params.codec = DEFAULT_CODEC;
     params.framerate = DEFAULT_FRAMERATE;
     params.audio_codec = DEFAULT_AUDIO_CODEC;


### PR DESCRIPTION
This PR stacks on top of #197 to change the default for wf-recorder to use only royalty-free codecs by default.

Fixes #196