### PR TITLE
meson: Use gnu variants of C/C++ standards

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,8 +6,8 @@ project(
 	license: 'MIT',
 	meson_version: '>=0.47.0',
 	default_options: [
-		'cpp_std=c++11',
-        'c_std=c11',
+		'cpp_std=gnu++11',
+		'c_std=gnu11',
 		'warning_level=2',
 		'werror=false',
 	],


### PR DESCRIPTION
This fixes the build for POWER systems because GNU variants force boolean types to follow the C/C++ standard (and remain scalar) rather than becoming vector with the POWER AltiVec extensions.

This has no change in behavior for non-POWER architectures.

Reference: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58241