### PR TITLE
README: Flesh out build dependencies for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ apt install wf-recorder
 
 #### Ubuntu
 ```
-sudo apt install libavutil-dev libavcodec-dev libavformat-dev libswscale-dev libpulse-dev
+sudo apt install g++ meson libavutil-dev libavcodec-dev libavformat-dev libswscale-dev libpulse-dev
 ```
 
 #### Fedora
 ```
-$ sudo dnf install wayland-devel wayland-protocols-devel ffmpeg-free-devel
+$ sudo dnf install gcc-c++ meson wayland-devel wayland-protocols-devel ffmpeg-free-devel pulseaudio-libs-devel
 ```
 
 ### Download & Build


### PR DESCRIPTION
When building on Ubuntu or Fedora, you need Meson and a C++ compiler. Additionally, add pulseaudio-libs-devel to have audio functionality for Fedora.