### PR TITLE
Use correct ffmpeg video filters when using hardware encoding

### DIFF
--- a/manpage/wf-recorder.1
+++ b/manpage/wf-recorder.1
@@ -111,7 +111,7 @@ installation supports by running
 .Dl $ ffmpeg -muxers
 .Pp
 .It Fl F , -filter Ar filter_string
-Set the ffmpeg filter to use. VAAPI requires `hwupload,scale_vaapi=nv12` to work.
+Set the ffmpeg filter to use. VAAPI requires `format=nv12,hwupload` to work.
 .Pp
 .It Fl g , -geometry Ar screen_geometry
 Selects a specific part of the screen. The format is "x,y WxH".

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -171,9 +171,9 @@ void FrameWriter::init_video_filters(const AVCodec *codec)
 {
     if (params.codec.find("vaapi") != std::string::npos) {
         if (params.video_filter == "null") {
-            // Add `hwupload,scale_vaapi=format=nv12` by default
+            // Add `format=nv12,hwupload` by default
             // It is necessary for conversion to a proper format.
-            params.video_filter = "hwupload,scale_vaapi=format=nv12";
+            params.video_filter = "format=nv12,hwupload";
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -605,7 +605,7 @@ Use Ctrl+C to stop.)");
                             -p <option_name>=<option_value>
 
   -F, --filter              Specify the ffmpeg filter string to use. For example,
-                            -F hwupload,scale_vaapi=format=nv12 is used for VAAPI.
+                            -F format=nv12,hwupload is used for VAAPI.
 
   -b, --bframes             This option is used to set the maximum number of b-frames to be used.
                             If b-frames are not supported by your hardware, set this to 0.


### PR DESCRIPTION
Should fix #148. Previous filter resulted in bad color format conversion.

https://trac.ffmpeg.org/wiki/Hardware/VAAPI#Encoding