### PR TITLE
Use correct AVColorRange

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -341,7 +341,6 @@ void FrameWriter::init_video_stream()
     videoCodecCtx->width      = params.width;
     videoCodecCtx->height     = params.height;
     videoCodecCtx->time_base  = US_RATIONAL;
-    videoCodecCtx->color_range = AVCOL_RANGE_JPEG;
     if (params.framerate) {
     std::cout << "Framerate: " << params.framerate << std::endl;
     }


### PR DESCRIPTION
yuv420p uses color values from 16-235, whereas yuvj420 uses values 0-255. ffmpeg will default to yuv420p if unspecified

* https://ffmpeg.org/doxygen/trunk/pixfmt_8h.html#a3da0bf691418bc22c4bcbe6583ad589a

Fixes #148 