### PR TITLE
Only flush when video codec has delay

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -790,13 +790,16 @@ FrameWriter::~FrameWriter()
     // Writing the delayed frames:
     AVPacket *pkt = av_packet_alloc();
 
-    encode(videoCodecCtx, NULL, pkt);
-#ifdef HAVE_PULSE
-    if (params.enable_audio)
+    if (videoCodecCtx->delay)
     {
-        encode(audioCodecCtx, NULL, pkt);
-    }
+        encode(videoCodecCtx, NULL, pkt);
+#ifdef HAVE_PULSE
+        if (params.enable_audio)
+        {
+            encode(audioCodecCtx, NULL, pkt);
+        }
 #endif
+    }
     // Writing the end of the file.
     av_write_trailer(fmtCtx);
 


### PR DESCRIPTION
Fixes error on ending recording.

Application provided invalid, non monotonically
increasing dts to muxer in stream 0: 58995 >= 56744