### PR TITLE
Break early when exit_main_loop is set in encoder thread

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -920,16 +920,13 @@ FrameWriter::~FrameWriter()
     // Writing the delayed frames:
     AVPacket *pkt = av_packet_alloc();
 
-    if (videoCodecCtx->delay)
-    {
-        encode(videoCodecCtx, NULL, pkt);
+    encode(videoCodecCtx, NULL, pkt);
 #ifdef HAVE_PULSE
-        if (params.enable_audio)
-        {
-            encode(audioCodecCtx, NULL, pkt);
-        }
-#endif
+    if (params.enable_audio)
+    {
+        encode(audioCodecCtx, NULL, pkt);
     }
+#endif
     // Writing the end of the file.
     av_write_trailer(fmtCtx);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -496,6 +496,10 @@ static void write_loop(FrameWriterParams params)
         while(buffers.encode().ready_encode() != true && !exit_main_loop) {
             std::this_thread::sleep_for(std::chrono::microseconds(1000));
         }
+        if (exit_main_loop) {
+            break;
+        }
+
         auto& buffer = buffers.encode();
 
         frame_writer_pending_mutex.lock();


### PR DESCRIPTION
Fixes error on ending recording.

Application provided invalid, non monotonically
increasing dts to muxer in stream 0: 58995 >= 56744