### PR TITLE
Add X2RGB10 format mapping for DMA-BUFs

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -145,6 +145,7 @@ static const struct {
     { GBM_FORMAT_RGBX8888, AV_PIX_FMT_0BGR },
     { GBM_FORMAT_BGRA8888, AV_PIX_FMT_ARGB },
     { GBM_FORMAT_BGRX8888, AV_PIX_FMT_0RGB },
+    { GBM_FORMAT_XRGB2101010, AV_PIX_FMT_X2RGB10 },
 };
 
 static AVPixelFormat get_drm_av_format(int fmt)


### PR DESCRIPTION
Requires https://patchwork.ffmpeg.org/project/ffmpeg/patch/20230809124554.160462-2-nowrep@gmail.com/
And for mesa driver it also requires https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/24353

Tested with `WLR_RENDERER=vulkan sway` + `output * render_bit_depth 10`.