### PR TITLE
Also set buffer.drm_format with shm capture

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -163,7 +163,7 @@ static AVPixelFormat get_drm_av_format(int fmt)
             return drm_av_format_table[i].av;
         }
     }
-    std::cerr << "Failed to find AV format for" << fmt;
+    std::cerr << "Failed to find AV format for" << fmt << std::endl;
     return AV_PIX_FMT_RGBA;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,6 +193,17 @@ static bool use_damage = true;
 static bool use_dmabuf = false;
 static bool use_hwupload = false;
 
+static uint32_t wl_shm_to_drm_format(uint32_t format)
+{
+    if (format == WL_SHM_FORMAT_ARGB8888) {
+        return GBM_FORMAT_ARGB8888;
+    } else if (format == WL_SHM_FORMAT_XRGB8888) {
+        return GBM_FORMAT_XRGB8888;
+    } else {
+        return format;
+    }
+}
+
 static void frame_handle_buffer(void *, struct zwlr_screencopy_frame_v1 *frame, uint32_t format,
     uint32_t width, uint32_t height, uint32_t stride)
 {
@@ -203,6 +214,7 @@ static void frame_handle_buffer(void *, struct zwlr_screencopy_frame_v1 *frame, 
     auto& buffer = buffers.capture();
 
     buffer.format = (wl_shm_format)format;
+    buffer.drm_format = wl_shm_to_drm_format(format);
     buffer.width = width;
     buffer.height = height;
     buffer.stride = stride;


### PR DESCRIPTION
HWFrames context uses drm_format to set correct sw_format even when not using DMA-BUF capture.