### PR TITLE
Set the default pixel format to yuv420p

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,6 +1,7 @@
 #pragma once
 
 #define DEFAULT_CODEC "@default_codec@"
+#define DEFAULT_PIX_FMT "@default_pix_fmt@"
 #define DEFAULT_AUDIO_CODEC "@default_audio_codec@"
 #define DEFAULT_AUDIO_SAMPLE_RATE @default_audio_sample_rate@
 #define DEFAULT_CONTAINER_FORMAT "@default_container_format@"

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ project(
 conf_data = configuration_data()
 
 conf_data.set('default_codec', get_option('default_codec'))
+conf_data.set('default_pix_fmt', get_option('default_pixel_format'))
 conf_data.set('default_audio_codec', get_option('default_audio_codec'))
 conf_data.set('default_audio_sample_rate', get_option('default_audio_sample_rate'))
 conf_data.set('default_container_format', get_option('default_container_format'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('default_codec', type: 'string', value: 'libx264', description: 'Codec that will be used by default')
+option('default_pixel_format', type: 'string', value: '', description: 'Pixel format that will be used by default')
 option('default_audio_codec', type: 'string', value: 'aac', description: 'Audio codec that will be used by default')
 option('default_audio_sample_rate', type: 'integer', value: 48000, description: 'Audio sample rate that will be used by default')
 option('default_container_format', type: 'string', value: 'mkv', description: 'Container file format that will be used by default')

--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -180,6 +180,10 @@ AVPixelFormat FrameWriter::lookup_pixel_format(std::string pix_fmt)
 
 AVPixelFormat FrameWriter::handle_buffersink_pix_fmt(const AVCodec *codec)
 {
+    /* If using the default codec and no pixel format is specified,
+     * set the format to yuv420p for web friendly output by default */
+    if (params.codec == DEFAULT_CODEC && params.pix_fmt.empty())
+        params.pix_fmt = "yuv420p";
 
     // Return with user chosen format
     if (!params.pix_fmt.empty())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -899,6 +899,7 @@ int main(int argc, char *argv[])
     FrameWriterParams params = FrameWriterParams(exit_main_loop);
     params.file = "recording." + std::string(DEFAULT_CONTAINER_FORMAT);
     params.codec = DEFAULT_CODEC;
+    params.pix_fmt = DEFAULT_PIX_FMT;
     params.audio_codec = DEFAULT_AUDIO_CODEC;
     params.sample_rate = DEFAULT_AUDIO_SAMPLE_RATE;
     params.enable_ffmpeg_debug_output = false;


### PR DESCRIPTION
Only when using the default codec and the pixel format is not set.
This makes the videos more web friendly by default.

Closes #152.