### PR TITLE
Add -q,--quit-after <seconds> option to limit recording time

### DIFF
--- a/manpage/wf-recorder.1
+++ b/manpage/wf-recorder.1
@@ -16,6 +16,7 @@
 .Op Fl -no-dmabuf
 .Op Fl D, -no-damage
 .Op Fl f Ar filename.ext
+.Op Fl q, -quit-after Ar seconds
 .Op Fl F Ar filter_string
 .Op Fl g, -geometry Ar geometry
 .Op Fl h, -help
@@ -115,6 +116,9 @@ You can check the muxers that your
 .Xr ffmpeg 1
 installation supports by running
 .Dl $ ffmpeg -muxers
+.Pp
+.It Fl q , -quit-after Ar seconds
+Stop recording after the specified seconds have elapsed and quit.
 .Pp
 .It Fl F , -filter Ar filter_string
 Set the ffmpeg filter to use. VAAPI requires `scale_vaapi=format=nv12:out_range=full` to work.


### PR DESCRIPTION
Awesome project

This pull request would add a "--quit-after <seconds>" option that allows you to simply limit the recording time automatically.

Among other things, this allows you to trivially create scripts which always recording to a rotating filename, thus allowing a cleanup process to remove old ones kind of like a tape loop.