### PR TITLE
ensure all status messages use stderr

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -80,7 +80,7 @@ void FrameWriter::load_codec_options(AVDictionary **dict)
 
     for (auto& opt : params.codec_options)
     {
-        std::cout << "Setting codec option: " << opt.first << "=" << opt.second << std::endl;
+        std::cerr << "Setting codec option: " << opt.first << "=" << opt.second << std::endl;
         av_dict_set(dict, opt.first.c_str(), opt.second.c_str(), 0);
     }
 }
@@ -89,7 +89,7 @@ void FrameWriter::load_audio_codec_options(AVDictionary **dict)
 {
     for (auto& opt : params.audio_codec_options)
     {
-        std::cout << "Setting codec option: " << opt.first << "=" << opt.second << std::endl;
+        std::cerr << "Setting codec option: " << opt.first << "=" << opt.second << std::endl;
         av_dict_set(dict, opt.first.c_str(), opt.second.c_str(), 0);
     }
 }
@@ -331,7 +331,7 @@ void FrameWriter::init_video_filters(const AVCodec *codec)
         exit(-1);
     }
 
-    std::cout << "Using video filter: " << params.video_filter << std::endl;
+    std::cerr << "Using video filter: " << params.video_filter << std::endl;
 
     err = avfilter_graph_parse_ptr(this->videoFilterGraph,
         params.video_filter.c_str(), &inputs, &outputs, NULL);
@@ -358,9 +358,9 @@ void FrameWriter::init_video_filters(const AVCodec *codec)
     }
 
     if (params.enable_ffmpeg_debug_output) {
-        std::cout << std::string(80,'#') << std::endl ;
-        std::cout << avfilter_graph_dump(this->videoFilterGraph,0) << "\n";
-        std::cout << std::string(80,'#') << std::endl ;
+        std::cerr << std::string(80,'#') << std::endl ;
+        std::cerr << avfilter_graph_dump(this->videoFilterGraph,0) << "\n";
+        std::cerr << std::string(80,'#') << std::endl ;
     }
 
 
@@ -405,7 +405,7 @@ void FrameWriter::init_video_stream()
     videoCodecCtx->time_base  = US_RATIONAL;
     videoCodecCtx->color_range = AVCOL_RANGE_JPEG;
     if (params.framerate) {
-    std::cout << "Framerate: " << params.framerate << std::endl;
+    std::cerr << "Framerate: " << params.framerate << std::endl;
     }
 
     if (params.bframes != -1)
@@ -510,16 +510,16 @@ static enum AVSampleFormat convert_codec_sample_fmt(const AVCodec *codec, std::s
     static enum AVSampleFormat converted_fmt = av_get_sample_fmt(requested_fmt.c_str());
     if (converted_fmt == AV_SAMPLE_FMT_NONE)
     {
-	std::cout << "Failed to find the given sample format: " << requested_fmt << std::endl;
-	std::exit(-1);
+        std::cerr << "Failed to find the given sample format: " << requested_fmt << std::endl;
+        std::exit(-1);
     } else if (!codec->sample_fmts || check_fmt_available(codec, converted_fmt))
     {
-        std::cout << "Using sample format " << av_get_sample_fmt_name(converted_fmt) << " for audio codec " << codec->name << std::endl;
+        std::cerr << "Using sample format " << av_get_sample_fmt_name(converted_fmt) << " for audio codec " << codec->name << std::endl;
         return converted_fmt;
     } else
     {
-	std::cout << "Codec " << codec->name << " does not support sample format " << av_get_sample_fmt_name(converted_fmt) << std::endl;
-	std::exit(-1);
+        std::cerr << "Codec " << codec->name << " does not support sample format " << av_get_sample_fmt_name(converted_fmt) << std::endl;
+        std::exit(-1);
     }
 }
 
@@ -546,7 +546,7 @@ void FrameWriter::init_audio_stream()
     if (params.sample_fmt.size() == 0) 
     {
         audioCodecCtx->sample_fmt = get_codec_auto_sample_fmt(codec);
-        std::cout << "Choosing sample format " << av_get_sample_fmt_name(audioCodecCtx->sample_fmt) << " for audio codec " << codec->name << std::endl;
+        std::cerr << "Choosing sample format " << av_get_sample_fmt_name(audioCodecCtx->sample_fmt) << " for audio codec " << codec->name << std::endl;
     } else 
     {
         audioCodecCtx->sample_fmt = convert_codec_sample_fmt(codec, params.sample_fmt);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -654,11 +654,11 @@ static bool user_specified_overwrite(std::string filename)
     if (stat (filename.c_str(), &buffer) == 0 && !S_ISCHR(buffer.st_mode))
     {
         std::string input;
-        std::cout << "Output file \"" << filename << "\" exists. Overwrite? Y/n: ";
+        std::cerr << "Output file \"" << filename << "\" exists. Overwrite? Y/n: ";
         std::getline(std::cin, input);
         if (input.size() && input[0] != 'Y' && input[0] != 'y')
         {
-            std::cout << "Use -f to specify the file name." << std::endl;
+            std::cerr << "Use -f to specify the file name." << std::endl;
             return false;
 	}
     }
@@ -783,7 +783,7 @@ static wf_recorder_output* detect_output_from_region(const capture_region& regio
         const capture_region output_region{wo.x, wo.y, wo.width, wo.height};
         if (region.contained_in(output_region))
         {
-            std::cout << "Detected output based on geometry: " << wo.name << std::endl;
+            std::cerr << "Detected output based on geometry: " << wo.name << std::endl;
             return &wo;
         }
     }
@@ -1120,7 +1120,7 @@ int main(int argc, char *argv[])
 
     if (params.codec.find("vaapi") != std::string::npos)
     {
-        std::cout << "using VA-API, trying to enable DMA-BUF capture..." << std::endl;
+        std::cerr << "using VA-API, trying to enable DMA-BUF capture..." << std::endl;
 
         // try compositor device if not explicitly set
         if (params.hw_device.empty())
@@ -1133,15 +1133,15 @@ int main(int argc, char *argv[])
         {
             use_dmabuf = true;
         } else if (force_no_dmabuf) {
-            std::cout << "Disabling DMA-BUF as requested on command line" << std::endl;
+            std::cerr << "Disabling DMA-BUF as requested on command line" << std::endl;
         } else {
-            std::cout << "compositor running on different device, disabling DMA-BUF" << std::endl;
+            std::cerr << "compositor running on different device, disabling DMA-BUF" << std::endl;
         }
 
         // region with dmabuf needs wlroots >= 0.17
         if (use_dmabuf && selected_region.is_selected())
         {
-            std::cout << "region capture may not work with older wlroots, try --no-dmabuf if it fails" << std::endl;
+            std::cerr << "region capture may not work with older wlroots, try --no-dmabuf if it fails" << std::endl;
         }
 
         if (params.video_filter == "null")
@@ -1155,7 +1155,7 @@ int main(int argc, char *argv[])
 
         if (use_dmabuf)
         {
-            std::cout << "enabled DMA-BUF capture, device " << params.hw_device.c_str() << std::endl;
+            std::cerr << "enabled DMA-BUF capture, device " << params.hw_device.c_str() << std::endl;
 
             drm_fd = open(params.hw_device.c_str(), O_RDWR);
             if (drm_fd < 0)

--- a/src/pulse.cpp
+++ b/src/pulse.cpp
@@ -25,7 +25,7 @@ PulseReader::PulseReader(PulseReaderParams _p)
     };
 
     int perr;
-    std::cout << "Using PulseAudio device: " << (params.audio_source ?: "default") << std::endl;
+    std::cerr << "Using PulseAudio device: " << (params.audio_source ?: "default") << std::endl;
     pa = pa_simple_new(NULL, "wf-recorder3", PA_STREAM_RECORD, params.audio_source,
         "wf-recorder3", &sample_spec, &map, &attr, &perr);
 


### PR DESCRIPTION
this means it's now possible to specify -f /dev/stdout and not have the messages break the stream.

closes #265  


---

this is the easy way to make output pipeable- by making wf-recorder behave like a normal cli program where non-data is always stderr.

the other option is to add an explicit --stdout option or similar where -f is ignored and it outputs to fd 1, but i think this works too :)