### PR TITLE
frame-writer: Use superfast instead of ultrafast for libx264/5

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -50,7 +50,7 @@ void FrameWriter::load_codec_options(AVDictionary **dict)
 
     static const CodecOptions default_x264_options = {
         {"tune", "zerolatency"},
-        {"preset", "ultrafast"},
+        {"preset", "superfast"},
         {"crf", "20"},
     };
 


### PR DESCRIPTION
This aims to default videos to use High profile by default instead of Constrained Baseline. This reportedly has more web compatibilty and makes video files slightly smaller.