### PR TITLE
frame-writer: Call the correct function for loading audio codec parameters

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -526,7 +526,7 @@ static enum AVSampleFormat convert_codec_sample_fmt(const AVCodec *codec, std::s
 void FrameWriter::init_audio_stream()
 {
     AVDictionary *options = NULL;
-    load_codec_options(&options);
+    load_audio_codec_options(&options);
     
     const AVCodec* codec = avcodec_find_encoder_by_name(params.audio_codec.c_str());
     if (!codec)


### PR DESCRIPTION
The function load_audio_codec_options() was implemented but the audio init function calls the function to load video codec options. As it was before this patch, load_audio_codec_options() was never called anywhere.

Fixes #291.