### PR TITLE
Move 'selected region' status message to stderr

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1278,7 +1278,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    printf("selected region %d,%d %dx%d\n", selected_region.x, selected_region.y, selected_region.width, selected_region.height);
+    fprintf(stderr, "selected region %d,%d %dx%d\n", selected_region.x, selected_region.y, selected_region.width, selected_region.height);
 
     bool spawned_thread = false;
     std::thread writer_thread;


### PR DESCRIPTION
This line was causing the image to be slightly translated to the right wrapping to the left when piping the rawvideo muxer to mpv (`wf-recorder -y -m rawvideo -c rawvideo -f /dev/stdout -x bgra | mpv - --demuxer=rawvideo --demuxer-rawvideo-mp-format=bgra --demuxer-rawvideo-w=1280 --demuxer-rawvideo-h=720`)