### PR TITLE
Fix recording with rotated monitors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -849,19 +849,20 @@ struct capture_region
             case WL_OUTPUT_TRANSFORM_FLIPPED:
             case WL_OUTPUT_TRANSFORM_FLIPPED_180:
             case WL_OUTPUT_TRANSFORM_90:
-                fprintf(stderr, "WL_OUTPUT_TRANSFORM_90\n");
+                fprintf(stderr, "90 degree rotation detected, altering geometry to compensate.\n");
                 std::swap(x, y);
                 x = -x;
                 break;
             case WL_OUTPUT_TRANSFORM_270:
-                fprintf(stderr, "WL_OUTPUT_TRANSFORM_270\n");
+                fprintf(stderr, "270 degree rotation detected, altering geometry to compensate.\n");
                 std::swap(x, y);
                 y = -y;
                 break;
             case WL_OUTPUT_TRANSFORM_FLIPPED_90:
             case WL_OUTPUT_TRANSFORM_FLIPPED_270:
             default:
-                fprintf(stderr, "Transform not found.\n");
+                fprintf(stderr, "Unknown transform value passed by compositor, using geometry as-is.\n");
+                transform = WL_OUTPUT_TRANSFORM_NORMAL;
                 break;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -844,10 +844,15 @@ struct capture_region
     void set_transform(const wf_recorder_output& wo) {
         transform = wo.transform;
         switch (transform) {
-            case WL_OUTPUT_TRANSFORM_NORMAL:
             case WL_OUTPUT_TRANSFORM_180:
+                //TODO
+                break;
             case WL_OUTPUT_TRANSFORM_FLIPPED:
+                //TODO
+                break;
             case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+                //TODO
+                break;
             case WL_OUTPUT_TRANSFORM_90:
                 fprintf(stderr, "90 degree rotation detected, altering geometry to compensate.\n");
                 std::swap(x, y);
@@ -859,7 +864,13 @@ struct capture_region
                 y = -y;
                 break;
             case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+                //TODO
+                break;
             case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+                //TODO
+                break;
+            case WL_OUTPUT_TRANSFORM_NORMAL:
+                break;
             default:
                 fprintf(stderr, "Unknown transform value passed by compositor, using geometry as-is.\n");
                 transform = WL_OUTPUT_TRANSFORM_NORMAL;
@@ -887,8 +898,14 @@ struct capture_region
     {
         switch (transform) {
             case WL_OUTPUT_TRANSFORM_180:
+                //TODO
+                break;
             case WL_OUTPUT_TRANSFORM_FLIPPED:
+                //TODO
+                break;
             case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+                //TODO
+                break;
             case WL_OUTPUT_TRANSFORM_90:
                 return
                     output.x <= abs(x) &&
@@ -902,8 +919,13 @@ struct capture_region
                     output.y <= abs(y) &&
                     output.y + output.height >= y + height;
             case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+                //TODO
+                break;
             case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-            default: //WL_OUTPUT_TRANSFORM_NORMAL
+                //TODO
+                break;
+            case WL_OUTPUT_TRANSFORM_NORMAL:
+            default:
                 return
                     output.x <= x &&
                     output.x + output.width >= x + width &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -464,13 +464,13 @@ static const struct zwp_linux_dmabuf_feedback_v1_listener dmabuf_feedback_listen
 
 static void
 display_handle_geometry(void *data,
-                        struct wl_output *wl_output,
-                        int32_t x, int32_t y,
-                        int32_t physical_width,
-                        int32_t physical_height,
-                        int32_t subpixel,
-                        const char *make,
-                        const char *model,
+                        struct wl_output *,
+                        int32_t, int32_t,
+                        int32_t,
+                        int32_t,
+                        int32_t,
+                        const char *,
+                        const char *,
                         int32_t transform)
 {
     wf_recorder_output *wo = (wf_recorder_output*) data;
@@ -479,38 +479,38 @@ display_handle_geometry(void *data,
 }
 
 static void
-display_handle_mode(void *data,
-                    struct wl_output *wl_output,
-                    uint32_t flags,
-                    int32_t width,
-                    int32_t height,
-                    int32_t refresh)
+display_handle_mode(void *,
+                    struct wl_output *,
+                    uint32_t,
+                    int32_t,
+                    int32_t,
+                    int32_t)
 {
 }
 
 static void
-display_handle_done(void *data, struct wl_output *wl_output)
+display_handle_done(void *, struct wl_output *)
 {
 }
 
 static void
-display_handle_scale(void *data,
-                     struct wl_output *wl_output,
-                     int32_t scale)
+display_handle_scale(void *,
+                     struct wl_output *,
+                     int32_t)
 {
 }
 
 static void
-display_handle_name(void *data,
-                    struct wl_output *wl_output,
-                    const char *name)
+display_handle_name(void *,
+                    struct wl_output *,
+                    const char *)
 {
 }
 
 static void
-display_handle_description(void *data,
-                           struct wl_output *wl_output,
-                           const char *description)
+display_handle_description(void *,
+                           struct wl_output *,
+                           const char *)
 {
 }
 


### PR DESCRIPTION
Addresses https://github.com/ammen99/wf-recorder/issues/173

Not sure this is the best way to go about this, but open to suggestions.

Only tested with 90 and 270 degree rotations because I can't handle mirroring. I guess I could add 180 degree rotation without too much work.

Still requires `-F transpose=` to be used get the actual output file to be rotated accordingly.

`wf-recorder -F transpose=1 --transform 1 -g "107,2000 1247x532" -f ~/Videos/test.mp4` works as expected on a monitor rotated 90 degrees, and coordinates grabbed via `slurp`.

`wf-recorder -F transpose=2 --transform 3 -g "107,2000 1247x532" -f ~/Videos/test.mp4` works the same when using 270 degree rotation.