### PR TITLE
Fix "Option 'pix_fmts' is not a runtime option"

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -335,17 +335,8 @@ void FrameWriter::init_video_filters(const AVCodec *codec)
         exit(-1);
     }
 
-    // We also need to tell the sink which pixel formats are supported.
-    // by the video encoder. codevIndicate to our sink  pixel formats
-    // are accepted by our codec.
-    const AVPixelFormat picked_pix_fmt[] =
-    {
-        handle_buffersink_pix_fmt(codec),
-        AV_PIX_FMT_NONE
-    };
-
-    err = av_opt_set_int_list(this->videoFilterSinkCtx, "pix_fmts",
-        picked_pix_fmt, AV_PIX_FMT_NONE, AV_OPT_SEARCH_CHILDREN);
+    err = av_opt_set(this->videoFilterSinkCtx, "pixel_formats",
+        codec->name, AV_OPT_SEARCH_CHILDREN);
 
     if (err < 0) {
         std::cerr << "Failed to set pix_fmts: " << averr(err) << std::endl;;

--- a/src/frame-writer.hpp
+++ b/src/frame-writer.hpp
@@ -105,6 +105,7 @@ class FrameWriter
     AVPixelFormat lookup_pixel_format(std::string pix_fmt);
     AVPixelFormat handle_buffersink_pix_fmt(const AVCodec *codec);
     AVPixelFormat get_input_format();
+    AVRational get_input_time_base();
     void init_hw_accel();
     void init_codecs();
     void init_video_filters(const AVCodec *codec);


### PR DESCRIPTION
Fixes #323 

This is all quite out of my depth by it looked doable thanks to knowing:
* On Arch Linux, downgrading ffmpeg to 7.1.1 was fixing the issue.
* Looking at the e-mail thread linked in the issue, someone hinted to look at ffmpeg's `doc/examples/decode_filter_video.c`. Looking at the history of the file, there were hints here and there of what could be done.

More details in the commits. Happy to hear if this wasn't an adequate fix!

### Testing done

Was able to record a video with the default parameters.