### PR TITLE
frame-writer: do not set output color range

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -470,9 +470,8 @@ void FrameWriter::init_video_stream()
     videoCodecCtx->width      = params.width;
     videoCodecCtx->height     = params.height;
     videoCodecCtx->time_base  = US_RATIONAL;
-    videoCodecCtx->color_range = AVCOL_RANGE_JPEG;
     if (params.framerate) {
-    std::cerr << "Framerate: " << params.framerate << std::endl;
+        std::cerr << "Framerate: " << params.framerate << std::endl;
     }
 
     if (params.bframes != -1)


### PR DESCRIPTION
The output color range should be detected by the codec itself, there is no reason for us to override it.

Fixes #331
