### PR TITLE
Actually use parsed audio options when opening audio codec

### DIFF
--- a/src/frame-writer.cpp
+++ b/src/frame-writer.cpp
@@ -630,7 +630,7 @@ void FrameWriter::init_audio_stream()
         audioCodecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
     int err;
-    if ((err = avcodec_open2(audioCodecCtx, codec, NULL)) < 0)
+    if ((err = avcodec_open2(audioCodecCtx, codec, &options)) < 0)
     {
         std::cerr << "(audio) avcodec_open2 failed " << err << std::endl;
         std::exit(-1);


### PR DESCRIPTION
The options were parsed but not passed to ffmpeg.

Fixes #291.