### PR TITLE
Add more examples on a dedicated documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,6 @@ To use GPU encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU 
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
 Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-x yuv420p` or `--pixel-format yuv420p` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the GPU.
+
+
+More examples [can be found here](doc/examples.md)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,5 @@ wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 ```
 Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-x yuv420p` or `--pixel-format yuv420p` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the GPU.
 
-
 ### More examples
 More examples [can be found here](doc/examples.md)

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ In its simplest form, run `wf-recorder` to start recording and use Ctrl+C to sto
 Use `-f <filename>` to specify the output file. In case of multiple outputs, you'll first be prompted to select the output you want to record. If you know the output name beforehand, you can use the `-o <output name>` option.
 To view all available output options, use the list flag `-L` or `--list-output`
 
+### Video cropping
 To select a specific part of the screen you can either use `-g <geometry>`, or use [slurp](https://github.com/emersion/slurp) for interactive selection of the screen area that will be recorded:
 
 ```
 wf-recorder -g "$(slurp)"
 ```
 
+### Audio recording
 You can record screen and sound simultaneously with
 
 ```
@@ -61,6 +63,7 @@ To specify a video codec, use the `-c <codec>` option. To modify codec parameter
 
 You can also specify an audio codec, using `-C <codec>`. Alternatively, the long form `--audio-codec` can be used. 
 
+### Supported video an audio codecs
 You can use the following command to check all available video codecs
 ```
 ffmpeg -hide_banner -encoders | grep -E '^ V' | grep -F '(codec' | cut -c 8- | sort
@@ -72,6 +75,7 @@ and the following for audio codecs
 ffmpeg -hide_banner -encoders | grep -E '^ A' | grep -F '(codec' | cut -c 8- | sort
 ```
 
+### Specifying the video muxer
 Use ffmpeg to get details about specific encoder, filter or muxer.
 
 To set a specific output format, use the `--muxer` option. For example, to output to a video4linux2 loopback you might use:
@@ -79,6 +83,7 @@ To set a specific output format, use the `--muxer` option. For example, to outpu
 wf-recorder --muxer=v4l2 --codec=rawvideo --file=/dev/video2
 ```
 
+### GPU-accelerated encoding with VAAPI
 To use GPU encoding, use a VAAPI codec (for ex. `h264_vaapi`) and specify a GPU device to use with the `-d` option:
 ```
 wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
@@ -86,4 +91,5 @@ wf-recorder -f test-vaapi.mkv -c h264_vaapi -d /dev/dri/renderD128
 Some drivers report support for rgb0 data for vaapi input but really only support yuv planar formats. In this case, use the `-x yuv420p` or `--pixel-format yuv420p` option in addition to the vaapi options to convert the data to yuv planar data before sending it to the GPU.
 
 
+### More examples
 More examples [can be found here](doc/examples.md)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To specify a video codec, use the `-c <codec>` option. To modify codec parameter
 
 You can also specify an audio codec, using `-C <codec>`. Alternatively, the long form `--audio-codec` can be used. 
 
-### Supported video an audio codecs
+### Supported video and audio codecs
 You can use the following command to check all available video codecs
 ```
 ffmpeg -hide_banner -encoders | grep -E '^ V' | grep -F '(codec' | cut -c 8- | sort

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -1,0 +1,112 @@
+# wf-recorder examples
+Below is a more extensive list of recording examples.
+
+### Table of Contents
+* [Find an encoder's parameters](#find-an-encoders-parameters)
+* [Fast x264 recording](#fast-x264-recording)
+* [Lossless video and RGB recording (H.264)](#lossless-video-and-rgb-recording-h-264)
+* [Lightweight video for editing](#lightweight-video-for-editing)
+* [Lossless or uncompressed audio (FLAC and PCM)](#lossless-or-uncompressed-audio-flac-and-pcm)
+
+## Find an encoder's parameters
+FFmpeg lets you see what parameters and supported pixel formats and sample formats for a particular encoder.
+The base for the command is `ffmpeg -h encoder=<encoder-name>`, for example:
+```
+ffmpeg -h encoder=libx264
+ffmpeg -h encoder=flac
+ffmpeg -h encoder=libvpx-vp9
+ffmpeg -h encoder=png
+```
+
+## Fast x264 recording
+By default, x264 uses the `medium` preset which is very slow for the CPU, not so appropriate for realtime recording.
+As you raise the preset from `veryfast` to placebo, the difference in compression efficiency and file size is very slight, sometimes negligible.
+
+The biggest difference comes in going from `ultrafast` to `superfast`, and `superfast` to `veryfast` has some improvements too.
+
+Using `superfast` or `veryfast` is ideal for realtime recording, though you can also resort to `ultrafast` if your CPU cannot keep up. You can set the preset with:
+```
+wf-recorder -c libx264 -p preset=superfast
+```
+
+## Lossless video and RGB recording (H.264)
+### Lossless
+The `x264` encoder can record in lossless compression. The `CRF` value adjust the video's control rate factor, in other words the quality of your video.
+CRF keeps the quality always the same throughout the video, while the bitrate (and file size) varies depending on how much data the video needs to achieve this level.
+
+A CRF value of 0 results in lossless compression:
+```
+wf-recorder -c libx264 -p crf=0
+```
+
+### RGB
+By default, x264 uses YUV pixel format, which can at worst result in less color information (if you use subsampling instead of YUV 4:4:4) or at best result some color destruction (RGB to YUV conversion).
+
+You can record in x264 using the RGB pixel format by using the `libx264rgb` encoder:
+```
+wf-recorder -c libx264rgb
+```
+
+The pixel format does not need to be specified. Recording in RGB also fixes other inaccurate video colors you might find.
+
+
+### True lossless
+Combining lossless and RGB encoding results in a video 100% identical to what you see on your screen:
+```
+wf-recorder -c libx264rgb -p crf=0
+```
+
+Expect your video's file size to be massive.
+
+
+## Lightweight video for editing
+Video editing can be very heavy, especially with high-resolution and high-framerate videos.
+Below are some ways to make your video faster to process in your editor. Note that all of these methods result in much bigger file sizes.
+
+### Disable inter-frame compression
+Inter-frame compression is a technique where frames share identical pixels with each other for sparing on bitrate. This makes the video slower to read.
+
+You can disable inter-frame compression with the `g` parameter:
+```sh
+wf-recorder -c libx264 -p g=20 # Sets the keyframe interval to every 20 frames (lower than usual), the lower it is the faster it is to decode the video
+wf-recorder -c libx264 -p g=0 # Disables inter-frame compression entirely
+```
+
+### Use an intermediate format
+Intermediate video formats are video encoding formats that have no inter-frame compression but also have very lightweight compression, resulting in very fast video playback at the cost of massive file sizes.
+These video formats also work with DaVinci Resolve on Linux.
+
+Here's some examples of intermediate formats:
+```sh
+wf-recorder -c dnxhd -p profile=dnxhr_hq # Very popular in professional video
+wf-recorder -c dnxhd -p profile=dnxhr_444 # Same as above, but YUV 4:4:4 pixels and much higher bitrate and encoding overhead
+
+wf-recorder -c cfhd -p quality=high # GoPro Cineform, also very good. The quality parameter defines the bitrate
+wf-recorder -c cfhd -p quality=film3+ # The highest bitrate, use with caution
+wf-recorder -c cfhd -p quality=high -x gbrp12le # 12bit/channel RGB, very heavy
+```
+
+
+## Lossless or uncompressed audio (FLAC and PCM)
+### Lossless
+FLAC is a lossless audio compression format, you can use it with:
+```
+wf-recorder -a -C flac
+```
+
+By default, the audio is recorded at 16bit. You can record at 32bit as well:
+```
+wf-recorder -a -C flac -X s32
+```
+
+### Uncompressed
+PCM encoders record uncompressed audio, directly equivalent to a WAV file.
+Multiple PCM encoders exist for different bit depths and integer, floating point precision and bit endianess. You can find all of them with:
+```
+ffmpeg -encoders | grep pcm_
+```
+
+24bit little endian example:
+```
+wf-recorder -a -C pcm_s24le
+```

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -1,4 +1,4 @@
-# Video and Audio recording examples
+# Video and Audio Recording Examples
 Below is a more extensive list of recording examples.
 
 ### Table of Contents

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -7,7 +7,7 @@ Below is a more extensive list of recording examples.
 * [Fast x264 recording](#fast-x264-recording)
 * [Lossless video and RGB recording (H.264)](#lossless-video-and-rgb-recording-h264)
 * [Lightweight video for editing](#lightweight-video-for-editing)
-* [Lossless or uncompressed audio (FLAC and PCM)](#lossless-or-uncompressed-audio-flac-and-pcm)
+* [Lossless audio](#lossless-audio)
 
 ## Find an encoder's parameters
 FFmpeg lets you see what parameters, pixel formats and sample formats a particular encoder supports.
@@ -123,26 +123,13 @@ wf-recorder -c cfhd -p quality=high -x gbrp12le # 12bit/channel RGB, very heavy
 ```
 
 
-## Lossless or uncompressed audio (FLAC and PCM)
-### Lossless
+## Lossless audio
 FLAC is a lossless audio compression format, you can use it with:
 ```
 wf-recorder -a -C flac
 ```
 
-By default, the audio is recorded at 16bit. You can record at 32bit as well:
+By default, the audio is recorded at 16bit. You can record as s32 (24bit) as well:
 ```
 wf-recorder -a -C flac -X s32
-```
-
-### Uncompressed
-PCM encoders record uncompressed audio, directly equivalent to a WAV file.
-Multiple PCM encoders exist for different bit depths and integer, floating point precision and bit endianess. You can find all of them with:
-```
-ffmpeg -encoders | grep pcm_
-```
-
-24bit little endian example:
-```
-wf-recorder -a -C pcm_s24le
 ```

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -4,7 +4,7 @@ Below is a more extensive list of recording examples.
 ### Table of Contents
 * [Find an encoder's parameters](#find-an-encoders-parameters)
 * [Fast x264 recording](#fast-x264-recording)
-* [Lossless video and RGB recording (H.264)](#lossless-video-and-rgb-recording-h-264)
+* [Lossless video and RGB recording (H.264)](#lossless-video-and-rgb-recording-h264)
 * [Lightweight video for editing](#lightweight-video-for-editing)
 * [Lossless or uncompressed audio (FLAC and PCM)](#lossless-or-uncompressed-audio-flac-and-pcm)
 

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -1,4 +1,4 @@
-# wf-recorder examples
+# Video and Audio recording examples
 Below is a more extensive list of recording examples.
 
 ### Table of Contents

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -3,6 +3,7 @@ Below is a more extensive list of recording examples.
 
 ### Table of Contents
 * [Find an encoder's parameters](#find-an-encoders-parameters)
+* [Setting video resolution and scale](#setting-video-resolution-and-scale)
 * [Fast x264 recording](#fast-x264-recording)
 * [Lossless video and RGB recording (H.264)](#lossless-video-and-rgb-recording-h264)
 * [Lightweight video for editing](#lightweight-video-for-editing)
@@ -17,6 +18,41 @@ ffmpeg -h encoder=flac
 ffmpeg -h encoder=libvpx-vp9
 ffmpeg -h encoder=png
 ```
+
+
+## Setting video resolution and scale
+You can scale your video's final resolution with an FFmpeg filter:
+
+### Specified resolution
+You can specify the width and height of your video, in this example to 1920x1080:
+```
+wf-recorder -F scale=1920:1080
+```
+
+### Specify width or height, keep aspect ratio
+You can set the width or height while keeping the aspect ratio, the other dimension is calculated:
+```sh
+wf-recorder -F scale=1920:-1 # Specifies width as 1920
+wf-recorder -F scale=-1:1080 # Specifies height as 1080
+```
+
+### Multiply or divide resolution
+```sh
+wf-recorder -F scale=iw/2:ih/2 # Divides the resolution by 2
+wf-recorder -F scale=iw*3:ih*3 # Multiplies the resolution by 3
+```
+
+### Scaling filters
+The scale filter uses the `sws_flags` parameter to determine the scaling algorithm. By default, bicubic is used.
+You can find out which filters are supported with `ffmpeg -h filter=scale`.
+
+Examples:
+```sh
+wf-recorder -F scale=iw*2:ih*w -p sws_flags=neighbor # Scales the video by 2 with nearest neighbor scaling
+wf-recorder -F scale=1920:1080 -p sws_flags=bilinear # Scales the video to 1920x1080 with bilinear scaling
+wf-recorder -F scale=1920:1080 -p sws_flags=lanczos # Scales the video to 1920x1080 with lanczos scaling
+```
+
 
 ## Fast x264 recording
 By default, x264 uses the `medium` preset which is very slow for the CPU, not so appropriate for realtime recording.

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -65,6 +65,7 @@ Using `superfast` or `veryfast` is ideal for realtime recording, though you can 
 wf-recorder -c libx264 -p preset=superfast
 ```
 
+
 ## Lossless video and RGB recording (H.264)
 ### Lossless
 The `x264` encoder can record in lossless compression. The `CRF` value adjusts the video's control rate factor, in other words the quality of your video.
@@ -84,7 +85,6 @@ wf-recorder -c libx264rgb
 ```
 
 The pixel format does not need to be specified. Recording in RGB also fixes other inaccurate video colors you might find.
-
 
 ### True lossless
 Combining lossless and RGB encoding results in a video 100% identical to what you see on your screen:

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -40,7 +40,7 @@ wf-recorder -c libx264 -p crf=0
 ```
 
 ### RGB
-By default, x264 uses YUV pixel format, which can at worst result in less color information (if you use subsampling instead of YUV 4:4:4) or at best result some color destruction (RGB to YUV conversion).
+By default, x264 uses the YUV pixel format, which can at worst result in less color information (if you use subsampling instead of YUV 4:4:4) or at best result in some color destruction (RGB to YUV conversion).
 
 You can record in x264 using the RGB pixel format by using the `libx264rgb` encoder:
 ```

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -31,7 +31,7 @@ wf-recorder -c libx264 -p preset=superfast
 
 ## Lossless video and RGB recording (H.264)
 ### Lossless
-The `x264` encoder can record in lossless compression. The `CRF` value adjust the video's control rate factor, in other words the quality of your video.
+The `x264` encoder can record in lossless compression. The `CRF` value adjusts the video's control rate factor, in other words the quality of your video.
 CRF keeps the quality always the same throughout the video, while the bitrate (and file size) varies depending on how much data the video needs to achieve this level.
 
 A CRF value of 0 results in lossless compression:

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -20,7 +20,7 @@ ffmpeg -h encoder=png
 
 ## Fast x264 recording
 By default, x264 uses the `medium` preset which is very slow for the CPU, not so appropriate for realtime recording.
-As you raise the preset from `veryfast` to placebo, the difference in compression efficiency and file size is very slight, sometimes negligible.
+As you raise the preset from `veryfast` to `placebo`, the difference in compression efficiency and file size is very slight, sometimes negligible.
 
 The biggest difference comes in going from `ultrafast` to `superfast`, and `superfast` to `veryfast` has some improvements too.
 

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -9,7 +9,7 @@ Below is a more extensive list of recording examples.
 * [Lossless or uncompressed audio (FLAC and PCM)](#lossless-or-uncompressed-audio-flac-and-pcm)
 
 ## Find an encoder's parameters
-FFmpeg lets you see what parameters and supported pixel formats and sample formats for a particular encoder.
+FFmpeg lets you see what parameters, pixel formats and sample formats a particular encoder supports.
 The base for the command is `ffmpeg -h encoder=<encoder-name>`, for example:
 ```
 ffmpeg -h encoder=libx264


### PR DESCRIPTION
This pull request adds a new file in `doc/examples.md` that contains a more extensive list of examples on how to record using wf-recorder, adding a deeper insight into FFmpeg capabilities.

It mentions lossless and RGB recording, intermediate formats and inter-frame compression, scaling the video, setting up x264 and more.

I also changed the readme and added a few small headers to the examples that were already in there. I kept the original examples in the readme, but I think we could also move them to the examples page or at least part of them.

I kept the manpage the same to not clutter it, similar to how the readme wasn't cluttered.